### PR TITLE
Tuple append write bug

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -6,11 +6,9 @@ version 1.8.2
 
 * Added time coordinate bounds to the polygon geometry example field
   returned by ``cfdm.example_field(6)``.
-* Fixed bug that caused failure when, in `cf.write`, the data array of
-  the field construct doesn't span the a particular domain axis but an
-  auxiliary coordinate, cell measure, domain ancillary or field
-  ancillary construct does, thereby requiring the data array to have a
-  dimension inserted to include it.
+* Fixed bug in `cfdm.write` that caused (what are effectively)
+  string-valued scalar auxiliary coordinates to not be written to disk
+  as such, or even a an exception to be raised.
   
 version 1.8.1
 -------------

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -6,7 +6,12 @@ version 1.8.2
 
 * Added time coordinate bounds to the polygon geometry example field
   returned by ``cfdm.example_field(6)``.
-
+* Fixed bug that caused failure when, in `cf.write`, the data array of
+  the field construct doesn't span the a particular domain axis but an
+  auxiliary coordinate, cell measure, domain ancillary or field
+  ancillary construct does, thereby requiring the data array to have a
+  dimension inserted to include it.
+  
 version 1.8.1
 -------------
 ----

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -870,6 +870,10 @@ class CFDMImplementation(Implementation):
     def get_field_data_axes(self, field):
         '''TODO
 
+    :Returns:
+        
+        `tuple`
+
         '''
         return field.get_data_axes()
          

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -298,12 +298,31 @@ class CFDMImplementation(Implementation):
         '''
         return data.array
 
+    def get_auxiliary_coordinates(self, field, axes=[], exact=False):
+        '''Return auxiliary coordinate constructs that span particular axes.
 
-    def get_auxiliary_coordinates(self, field):
-        '''TODO
+    If no axes are specified then all auxiliary coordinate constructs
+    are returned.
+    
+    If axes are specified then auxiliary coordinate constructs whose
+    data arrays span those axes, and possibly other axes, are
+    returned.
+    
+    :Parameters:
+    
+        axes: sequence of `str`
+    
+    :Returns:
+    
+        `dict`
+
         '''
-        return field.auxiliary_coordinates
+        if exact:
+            return dict(field.auxiliary_coordinates.filter_by_axis(
+                'exact', *axes))
 
+        return dict(field.auxiliary_coordinates.filter_by_axis(
+            'and', *axes))
 
     def get_bounds(self, parent, default=None):
         '''TODO
@@ -447,7 +466,6 @@ class CFDMImplementation(Implementation):
 
         '''
         return dict(field.constructs.filter_by_axis('and', *axes))
-
     
     def get_coordinate_reference_coordinates(self, coordinate_reference):
         '''Return the coordinates of a coordinate reference object.

--- a/cfdm/core/__init__.py
+++ b/cfdm/core/__init__.py
@@ -3,9 +3,9 @@
 '''
 
 __author__       = 'David Hassell'
-__date__         = '2020-04-16'
+__date__         = '2020-04-22'
 __cf_version__   = '1.8'
-__version__      = '1.8.1'
+__version__      = '1.8.2b1'
 
 from distutils.version import LooseVersion
 import platform

--- a/cfdm/core/__init__.py
+++ b/cfdm/core/__init__.py
@@ -3,9 +3,9 @@
 '''
 
 __author__       = 'David Hassell'
-__date__         = '2020-04-22'
+__date__         = '2020-??-??'
 __cf_version__   = '1.8'
-__version__      = '1.8.2b1'
+__version__      = '1.8.2'
 
 from distutils.version import LooseVersion
 import platform

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -2140,7 +2140,7 @@ class NetCDFRead(IORead):
                     coord = self._create_auxiliary_coordinate(
                         field_ncvar, ncvar, f)
                     g['auxiliary_coordinate'][ncvar] = coord
-     
+
                 # --------------------------------------------------------
                 # Turn a 
                 # --------------------------------------------------------
@@ -2150,17 +2150,20 @@ class NetCDFRead(IORead):
                     scalar = True
 #                    if g['variables'][ncvar].dtype.kind is 'S':
                     if self._is_char_or_string(ncvar):
-                        # String valued scalar coordinate. Is this CF
-                        # compliant? Don't worry about it - we'll just
-                        # turn it into a 1-d, size 1 auxiliary coordinate
-                        # construct.
+                        # String valued scalar coordinate. T turn it
+                        # into a 1-d auxiliary coordinate construct.
                         domain_axis = self._create_domain_axis(1)
                         if verbose:
                             print('    [4] Inserting',
                                   repr(domain_axis)) # pragma: no cover
                         dim = self.implementation.set_domain_axis(
                             f, domain_axis)
+                                        
                         dimensions = [dim]
+
+#                        coord = self.implementation.construct_insert_dimension#(
+#                            construct=coord, position=0)
+#                        g['auxiliary_coordinate'][ncvar] = coord
                     else:  
                         # Numeric valued scalar coordinate
                         is_scalar_dimension_coordinate = True

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -2161,9 +2161,9 @@ class NetCDFRead(IORead):
                                         
                         dimensions = [dim]
 
-#                        coord = self.implementation.construct_insert_dimension#(
-#                            construct=coord, position=0)
-#                        g['auxiliary_coordinate'][ncvar] = coord
+                        coord = self.implementation.construct_insert_dimension(
+                            construct=coord, position=0)
+                        g['auxiliary_coordinate'][ncvar] = coord
                     else:  
                         # Numeric valued scalar coordinate
                         is_scalar_dimension_coordinate = True

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -2751,8 +2751,7 @@ class NetCDFWrite(IOWrite):
         for key, aux_coord in sorted(
                 self.implementation.get_auxiliary_coordinates(f).items()):
             axes = self.implementation.get_construct_data_axes(f, key)
-            print (axes, data_axes)
-            if len(axes) > 1 or axis[0] in data_axes:
+            if len(axes) > 1 or axes[0] in data_axes:
                 # This auxiliary coordinate construct spans at least
                 # one of the dimensions of the field constuct's data
                 # array.

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -2529,31 +2529,61 @@ class NetCDFWrite(IOWrite):
                 # --------------------------------------------------------
                 # There is NO dimension coordinate for this axis
                 # --------------------------------------------------------
-                spanning_constructs = self.implementation.get_constructs(f, axes=[axis])
+                spanning_constructs = (
+                    self.implementation.get_constructs(f, axes=[axis])
+                )
 
-                if axis not in data_axes and spanning_constructs:
+                spanning_auxiliary_coordinates = (
+                    self.implementation.get_auxiliary_coordinates(
+                        f, axes=[axis], exact=True)
+                )
+                
+                if (axis not in data_axes
+                    and spanning_constructs
+                    and spanning_constructs != spanning_auxiliary_coordinates):
                     # The data array doesn't span the domain axis but
-                    # an auxiliary coordinate, cell measure, domain
-                    # ancillary or field ancillary does, so expand the
-                    # data array to include it.
+                    # a cell measure, domain ancillary or field
+                    # ancillary does, or an N-d (N>1) auxiliary
+                    # coordinate does, so expand the data array to
+                    # include it.
                     f = self.implementation.field_insert_dimension(
                             f, position=0, axis=axis)
                     data_axes.append(axis)
+                    
+#                spanning_constructs = self.implementation.get_constructs(f, axes=[axis])
+#
+#                if axis not in data_axes and spanning_constructs:
+#                    # The data array doesn't span the domain axis but
+#                    # an auxiliary coordinate, cell measure, domain
+#                    # ancillary or field ancillary does, so expand the
+#                    # data array to include it.
+#                    f = self.implementation.field_insert_dimension(
+#                            f, position=0, axis=axis)
+#                    data_axes.append(axis)
     
                 # If the data array (now) spans this domain axis then create a
                 # netCDF dimension for it
                 if axis in data_axes:
-                    axis_size0 = self.implementation.get_domain_axis_size(f, axis)
+                    axis_size0 = (
+                        self.implementation.get_domain_axis_size(f, axis)
+                    )
                 
                     use_existing_dimension = False
 
                     if spanning_constructs:
-                        for key, construct in list(spanning_constructs.items()):
-                            axes = self.implementation.get_construct_data_axes(f, key)
-                            spanning_constructs[key] = (construct, axes.index(axis))
+                        for key, construct in list(
+                                spanning_constructs.items()):
+                            axes = (
+                                self.implementation.get_construct_data_axes(
+                                    f, key)
+                            )
+                            spanning_constructs[key] = (construct,
+                                                        axes.index(axis))
 
                         for b1 in g['xxx']:
-                            (ncdim1,  axis_size1),  constructs1 = list(b1.items())[0]
+                            (ncdim1,  axis_size1),  constructs1 = (
+                                list(b1.items())[0]
+                            )
 
                             if axis_size0 != axis_size1:
                                 continue
@@ -2613,6 +2643,7 @@ class NetCDFWrite(IOWrite):
                         self._write_dimension(ncdim, f, axis, unlimited=unlimited)
                         
                         xxx.append({(ncdim, axis_size0): spanning_constructs})
+                # --- End: if
             # --- End: if    
         # --- End: for
 
@@ -2717,9 +2748,25 @@ class NetCDFWrite(IOWrite):
         # ----------------------------------------------------------------
         # Initialize the list of 'coordinates' attribute variable values
         # (each of the form 'name')
-        for key, aux_coord in sorted(self.implementation.get_auxiliary_coordinates(f).items()):
-            coordinates = self._write_auxiliary_coordinate(f, key, aux_coord,
-                                                           coordinates)
+        for key, aux_coord in sorted(
+                self.implementation.get_auxiliary_coordinates(f).items()):
+            axes = self.implementation.get_construct_data_axes(f, key)
+            print (axes, data_axes)
+            if len(axes) > 1 or axis[0] in data_axes:
+                # This auxiliary coordinate construct spans at least
+                # one of the dimensions of the field constuct's data
+                # array.
+                coordinates = self._write_auxiliary_coordinate(f, key,
+                                                               aux_coord,
+                                                               coordinates)
+            else:
+                # This auxiliary coordinate needs to be written as a
+                # scalar coordiante variable
+                coordinates = self._write_scalar_coordinate(f, key,
+                                                            aux_coord,
+                                                            axis,
+                                                            coordinates)
+        # --- End: for
     
         # ------------------------------------------------------------
         # Create netCDF variables from domain ancillaries

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -2367,7 +2367,7 @@ class NetCDFWrite(IOWrite):
         # terrible things to it (or are we? should review this)
         f = self.implementation.copy_construct(org_f)
 
-        data_axes = self.implementation.get_field_data_axes(f)
+        data_axes = list(self.implementation.get_field_data_axes(f))
     
         # Mapping of domain axis identifiers to netCDF dimension
         # names. This gets reset for each new field that is written to

--- a/cfdm/test/setup_create_field.py
+++ b/cfdm/test/setup_create_field.py
@@ -8,7 +8,7 @@ import numpy
 
 import cfdm
 
-verbose  =  False
+verbose  = True # False
 warnings = False
 
 
@@ -195,7 +195,8 @@ class create_fieldTest(unittest.TestCase):
 
         if verbose:
             print("####################################################")
-            
+
+        print (f)
         cfdm.write(f, self.filename, fmt='NETCDF3_CLASSIC', verbose=verbose)
 
         g = cfdm.read(self.filename, verbose=verbose)

--- a/cfdm/test/setup_create_field.py
+++ b/cfdm/test/setup_create_field.py
@@ -8,7 +8,7 @@ import numpy
 
 import cfdm
 
-verbose  = True # False
+verbose  = False
 warnings = False
 
 
@@ -196,7 +196,6 @@ class create_fieldTest(unittest.TestCase):
         if verbose:
             print("####################################################")
 
-        print (f)
         cfdm.write(f, self.filename, fmt='NETCDF3_CLASSIC', verbose=verbose)
 
         g = cfdm.read(self.filename, verbose=verbose)
@@ -251,7 +250,7 @@ class create_fieldTest(unittest.TestCase):
 
         if verbose:            
             for x in g:
-                x.print_read_report()
+                x.dataset_compliance(display=True)
 
             print(g)
             
@@ -276,6 +275,6 @@ class create_fieldTest(unittest.TestCase):
 
 if __name__ == "__main__":
     print('Run date:', datetime.datetime.now())
-    print(cfdm.environment(display=False))
+    cfdm.environment(display=True)
     print('')
     unittest.main(verbosity=2)

--- a/cfdm/test/test_Field.py
+++ b/cfdm/test/test_Field.py
@@ -22,6 +22,7 @@ class FieldTest(unittest.TestCase):
                                                'DSG_timeSeriesProfile_indexed_contiguous.nc')
 
         f = cfdm.read(self.filename)
+        print(f)
         self.assertTrue(len(f)==1, 'f={}'.format(f))
         self.f = f[0]
 

--- a/cfdm/test/test_Field.py
+++ b/cfdm/test/test_Field.py
@@ -22,7 +22,6 @@ class FieldTest(unittest.TestCase):
                                                'DSG_timeSeriesProfile_indexed_contiguous.nc')
 
         f = cfdm.read(self.filename)
-        print(f)
         self.assertTrue(len(f)==1, 'f={}'.format(f))
         self.f = f[0]
 

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -16,6 +16,7 @@ warnings = False
 
 tmpfile  = tempfile.mktemp('.cfdm_test')
 tmpfileh  = tempfile.mktemp('.cfdm_test')
+tmpfileh2 = tempfile.mktemp('.cfdm_test')
 tmpfilec  = tempfile.mktemp('.cfdm_test')
 tmpfile0  = tempfile.mktemp('.cfdm_test')
 tmpfile1  = tempfile.mktemp('.cfdm_test')
@@ -212,23 +213,23 @@ class read_writeTest(unittest.TestCase):
         with self.assertRaises(OSError):
             x = cfdm.read('test_read_write.py')
 
-        for number, regex in enumerate([
+        for regex in [
             r'"1 i\ \ "',
             r'"1 i\// comment"',
             r'"1 i\ // comment"',
             r'"1 i\ \t// comment"'
-        ]):
-            # Empty string is an effective extension option needed w/ BSD sed:
-            try:  # for GNU (Linux OS) and older BSD variants (older Mac OS)
-                subprocess.run(
-                    ' '.join(['sed', '-i', '', regex, tmpfileh]),
-                    shell=True, check=True
-                )
-            except subprocess.CalledProcessError:  # for newer BSD i.e. Mac OS
-                subprocess.run(
-                    ' '.join(['sed', "-i''", regex, tmpfileh]),
-                    shell=True, check=True
-                )
+        ]:
+            # Note that really we just want to do an in-place sed ('sed -i')
+            # but because of subtle differences between the GNU (Linux OS) and
+            # BSD (some Mac OS) command variants a safe portable one-liner may
+            # not be possible. This will do, overwriting the intermediate file.
+            # The '-E' to mark as an extended regex is also for portability.
+            subprocess.run(
+                ' '.join(['sed', '-E', '-e', regex, tmpfileh, '>' + tmpfileh2,
+                          '&&', 'mv', tmpfileh2, tmpfileh]),
+                shell=True, check=True
+            )
+
             h = cfdm.read(tmpfileh)[0]
 
 #        subprocess.run(' '.join(['head', tmpfileh]),  shell=True, check=True)

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -212,16 +212,23 @@ class read_writeTest(unittest.TestCase):
         with self.assertRaises(OSError):
             x = cfdm.read('test_read_write.py')
 
-        for regex in [
+        for number, regex in enumerate([
             r'"1 i\ \ "',
             r'"1 i\// comment"',
             r'"1 i\ // comment"',
             r'"1 i\ \t// comment"'
-        ]:
-            subprocess.run(
-                ' '.join(['sed', '-i".bak"', '-e', regex, tmpfileh]),
-                shell=True, check=True
-            )
+        ]):
+            # Empty string is an effective extension option needed w/ BSD sed:
+            try:  # for GNU (Linux OS) and older BSD variants (older Mac OS)
+                subprocess.run(
+                    ' '.join(['sed', '-i', '', regex, tmpfileh]),
+                    shell=True, check=True
+                )
+            except subprocess.CalledProcessError:  # for newer BSD i.e. Mac OS
+                subprocess.run(
+                    ' '.join(['sed', "-i''", regex, tmpfileh]),
+                    shell=True, check=True
+                )
             h = cfdm.read(tmpfileh)[0]
 
 #        subprocess.run(' '.join(['head', tmpfileh]),  shell=True, check=True)

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -211,22 +211,18 @@ class read_writeTest(unittest.TestCase):
 
         with self.assertRaises(OSError):
             x = cfdm.read('test_read_write.py')
-            
-        subprocess.run(' '.join(['sed', '-i', r'"1 i\ \ "', tmpfileh]),
-                       shell=True, check=True)
-        h = cfdm.read(tmpfileh)[0]
-        
-        subprocess.run(' '.join(['sed', '-i', r'"1 i\// comment"', tmpfileh]),
-                       shell=True, check=True)
-        h = cfdm.read(tmpfileh)[0]
 
-        subprocess.run(' '.join(['sed', '-i', r'"1 i\ // comment"', tmpfileh]),
-                       shell=True, check=True)
-        h = cfdm.read(tmpfileh)[0]
-
-        subprocess.run(' '.join(['sed', '-i', r'"1 i\ \t// comment"', tmpfileh]),
-                       shell=True, check=True)
-        h = cfdm.read(tmpfileh)[0]
+        for regex in [
+            r'"1 i\ \ "',
+            r'"1 i\// comment"',
+            r'"1 i\ // comment"',
+            r'"1 i\ \t// comment"'
+        ]:
+            subprocess.run(
+                ' '.join(['sed', '-i".bak"', '-e', regex, tmpfileh]),
+                shell=True, check=True
+            )
+            h = cfdm.read(tmpfileh)[0]
 
 #        subprocess.run(' '.join(['head', tmpfileh]),  shell=True, check=True)
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -213,8 +213,8 @@ constructs, which include the first and last values of their data
 arrays:
 
 .. code-block:: python
-  :caption: *Inspect the contents of the two field constructs with
-            medium detail.*
+   :caption: *Inspect the contents of the two field constructs with
+             medium detail.*
    
    >>> print(q)
    Field: specific_humidity (ncvar%q)
@@ -258,8 +258,8 @@ properties of all constructs, including metadata constructs and their
 components, and shows the first and last values of all data arrays:
 
 .. code-block:: python
-  :caption: *Inspect the contents of the two field constructs with
-            full detail.*
+   :caption: *Inspect the contents of the two field constructs with
+             full detail.*
 
    >>> q.dump()
    ----------------------------------
@@ -954,8 +954,8 @@ field. Subspacing uses the same :ref:`cfdm indexing rules <Indexing>`
 that apply to the `Data` class.
 
 .. code-block:: python
-  :caption: *Create a new field whose domain spans the first longitude
-            of the original, and with a reversed latitude axis.*
+   :caption: *Create a new field whose domain spans the first longitude
+             of the original, and with a reversed latitude axis.*
 
    >>> print(q)
    Field: specific_humidity (ncvar%q)


### PR DESCRIPTION
Fix bug in `cfdm.write` that caused (what are effectively) string-valued scalar auxiliary coordinates to not be written to disk as such, or even a an exception to be raised.