### PR TITLE
Test update to GitHub Actions (Codecov coverage reports)

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -98,17 +98,15 @@ jobs:
     - name: Upload coverage report to Codecov
       # Get coverage for the two latest distros but only one Python version to
       # treat as representative (probably overkill to get on any more jobs).
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1.0.6
       if: |
         (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') &&
         matrix.python-version == 3.7
       with:
-        file: ./coverage.xml
-        directory: ./cfdm_coverage_reports
+        file: ./cfdm/test/cfdm_coverage_reports/coverage.xml
+        fail_ci_if_error: true
         flags: unittests
         name: codecov-umbrella
-        fail_ci_if_error: true
-        path_to_write_report: ./cfdm_coverage_reports/codecov_report.gz
 
     # End with a message indicating the suite has completed its run
     - name: Notify about a completed run

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -102,7 +102,6 @@ jobs:
       if: |
         (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') &&
         matrix.python-version == 3.7
-      shell: bash -l {0}
       with:
         file: ./coverage.xml
         directory: ./cfdm_coverage_reports

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Upload coverage report to Codecov
       # Get coverage for the two latest distros but only one Python version to
       # treat as representative (probably overkill to get on any more jobs).
-      uses: codecov/codecov-action@v1.0.6
+      uses: codecov/codecov-action@v1.0.7
       if: |
         (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') &&
         matrix.python-version == 3.7

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -93,6 +93,24 @@ jobs:
       run: |
         cd cfdm/test
         ./run_tests_and_coverage --nohtml
+
+    # For the two latest OSs only, generate a coverage report:
+    - name: Upload coverage report to Codecov
+      # Get coverage for the two latest distros but only one Python version to
+      # treat as representative (probably overkill to get on any more jobs).
+      uses: codecov/codecov-action@v1
+      if: |
+        (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') &&
+        matrix.python-version == 3.7
+      shell: bash -l {0}
+      with:
+        file: ./coverage.xml
+        directory: ./cfdm_coverage_reports
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: true
+        path_to_write_report: ./cfdm_coverage_reports/codecov_report.gz
+
     # End with a message indicating the suite has completed its run
     - name: Notify about a completed run
       run: |

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Upload coverage report to Codecov
       # Get coverage for the two latest distros but only one Python version to
       # treat as representative (probably overkill to get on any more jobs).
-      uses: codecov/codecov-action@v1.0.7
+      uses: codecov/codecov-action@v1.0.13
       if: |
         (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') &&
         matrix.python-version == 3.7

--- a/cfdm/test/run_tests_and_coverage
+++ b/cfdm/test/run_tests_and_coverage
@@ -13,6 +13,12 @@
 
 library=cfdm
 
+# Parse options. Note that xml is required for codecov:
+if [[ $1 == "--noxml" ]] ; then 
+    generate_xml="false"
+else
+    generate_xml="true"
+fi
 if [[ $1 == "--nohtml" ]] ; then 
     generate_html="false"
 else
@@ -32,13 +38,21 @@ rc=$?
 
 coverage report
 
+cov_dir=${library}_coverage_reports
+mkdir -p $cov_dir
+echo "coverage docs: https://coverage.readthedocs.io"
 if [[ $generate_html == "true" ]] ; then
-    dir=${library}_coverage_report
-    mkdir -p $dir
-    coverage html --title "$library test suite coverage report" -d $dir
-    
-    echo "coverage docs: https://coverage.readthedocs.io"
-    echo "coverage report URL: file://$PWD/$dir/index.html"
+    html_dir=$cov_dir/html
+    mkdir $html_dir
+    coverage html --title "$library test suite coverage report" -d $html_dir
+
+    echo "coverage HTML report URL: file://$PWD/$html_dir/index.html"
+fi
+if [[ $generate_xml == "true" ]] ; then
+    coverage xml
+    mv "coverage.xml" $cov_dir/"coverage.xml"
+
+    echo "coverage XML report URL: file://$PWD/$cov_dir/coverage.xml"
 fi
 
 # Return exit status from unit tests


### PR DESCRIPTION
Updates to our workflow to run the test suite, aiming to upload a coverage report to Codecov for two jobs, one each for the latest distros for Ubuntu and Mac using Python 3.7 as a representative Python version (I think it would be superfluous & a waste of Actions jobs to upload further coverage reports, since each job should give a very similar if not identical figure).

Testing in this PR to try to get the two coverage reports to show as a pair of 'checks' tied to the PR. Once I get that working, I can merge the PR.