### PR TITLE
Customise Codecov configuration

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -96,12 +96,16 @@ jobs:
 
     # For the two latest OSs only, generate a coverage report:
     - name: Upload coverage report to Codecov
-      # Get coverage for the two latest distros but only one Python version to
-      # treat as representative (probably overkill to get on any more jobs).
+      # Get coverage from only one job (choose with Ubuntu Python 3.7 as
+      # representative). Note that we could use a separate workflow
+      # to setup Codecov reports, but given the amount of steps required to
+      # install including dependencies via conda, that a separate workflow
+      # would have to run anyway, it is simplest to add it in this flow.
+      # Also, it means code coverage is only generated if the test suite is
+      # passing at least for that job, avoiding useless coverage reports.
       uses: codecov/codecov-action@v1.0.13
       if: |
-        (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') &&
-        matrix.python-version == 3.7
+        matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7
       with:
         file: ./cfdm/test/cfdm_coverage_reports/coverage.xml
         fail_ci_if_error: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,35 @@
+# This config overrides the default Codecov config, as outlined at:
+# https://docs.codecov.io/docs/codecov-yaml
+
+coverage:
+  round: up
+  range: "70...100"
+  precision: 2
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: "0%"
+        base: auto
+        branches: 
+          - master
+        if_no_uploads: success
+        if_not_found: success  
+        if_ci_failed: error
+        only_pulls: true
+    patch:
+      default:
+        target: "90%"
+        threshold: "10%"
+        base: auto
+        branches:
+          - master
+        if_no_uploads: success
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+
+# Note: there is a Codecov 'ignore' key to ignore certain paths, but this is
+# not needed (I think) since we ignore the test directory path etc. in
+# generating our coverage XML, so it should already not be processed.


### PR DESCRIPTION
The purpose of this PR is two-fold:

* tweak the default Codecov config to pass or fail he Github Actions / CI steps to be more appropriate to our current coverage levels and general dev. workflow;
* check that, now at least one Codecov report has been generated on cfdm for the first time, a 'pull request base' is detected and used as a reference for calculating coverage changes (compare to [the initial report](https://github.com/NCAS-CMS/cfdm/pull/79#issuecomment-698808883) where no base was found).