### PR TITLE
Decorator to implement display argument print or return

### DIFF
--- a/cfdm/__init__.py
+++ b/cfdm/__init__.py
@@ -108,6 +108,7 @@ from .decorators import (
     _inplace_enabled,
     _inplace_enabled_define_and_cleanup,
     _manage_log_level_via_verbosity,
+    _display_or_return,
 )
 
 from .constructs import Constructs

--- a/cfdm/coordinatereference.py
+++ b/cfdm/coordinatereference.py
@@ -7,7 +7,8 @@ from . import Datum
 
 from .data import Data
 
-from .decorators import _manage_log_level_via_verbosity
+from .decorators import (_manage_log_level_via_verbosity,
+                         _display_or_return)
 
 
 logger = logging.getLogger(__name__)
@@ -273,6 +274,7 @@ class CoordinateReference(mixin.NetCDFVariable,
 
         return out
 
+    @_display_or_return
     def dump(self, display=True, _omit_properties=None, field=None,
              key='', _level=0, _title=None, _construct_names=None,
              _auxiliary_coordinates=None, _dimension_coordinates=None):
@@ -349,12 +351,7 @@ class CoordinateReference(mixin.NetCDFVariable,
             for identifier in sorted(self.coordinates()):
                 string.append('{0}Coordinate: {1}'.format(indent1, identifier))
 
-        string = '\n'.join(string)
-
-        if display:
-            print(string)
-        else:
-            return string
+        return '\n'.join(string)
 
     @_manage_log_level_via_verbosity
     def equals(self, other, rtol=None, atol=None, verbose=None,

--- a/cfdm/decorators.py
+++ b/cfdm/decorators.py
@@ -22,7 +22,7 @@ INPLACE_ENABLED_PLACEHOLDER = '_to_assign'
 def _inplace_enabled(operation_method=None, *, default=False):
     '''A decorator enabling operations to be applied in-place.
 
-    If the decorated method has keyword argument *inplace* being equal
+    If the decorated method has keyword argument ``inplace`` being equal
     to True, the function will be performed on `self` and return None,
     otherwise it will operate on a copy of ``self`` and return the
     processed copy.
@@ -238,13 +238,21 @@ def _test_decorator_args(*dec_args):
     return deprecated_kwarg_check_decorator
 
 
-def _display_or_return(method):
-    '''A wrapper for TODO ... .'''
+def _display_or_return(method_with_display_kwarg):
+    '''A decorator enabling a string to be printed rather than returned.
 
-    @wraps(method)
+    If the decorated method has keyword argument ``display`` being equal
+    to True, by default or from being set as such, the function will
+    print the output that would otherwise be returned and return `None`.
+
+    :Parameters:
+
+        method_with_display_kwarg: method
+
+    '''
+    @wraps(method_with_display_kwarg)
     def end_with_display_or_return_logic(self, *args, **kwargs):
-        '''A wrapper for TODO ... .'''
-        string = method(self, *args, **kwargs)
+        string = method_with_display_kwarg(self, *args, **kwargs)
 
         # display=True is always default, so if display not provided, set True
         display = kwargs.get('display', True)

--- a/cfdm/decorators.py
+++ b/cfdm/decorators.py
@@ -31,7 +31,7 @@ def _inplace_enabled(operation_method=None, *, default=False):
     variable storing the relevant instance for use throughout the
     method to ``_inplace_enabled_define_and_cleanup(self)``.
 
-    :Parmaeters:
+    :Parameters:
 
         operation_method: method
 
@@ -236,3 +236,22 @@ def _test_decorator_args(*dec_args):
         return precede_with_kwarg_deprecation_check
 
     return deprecated_kwarg_check_decorator
+
+
+def _display_or_return(method):
+    '''A wrapper for TODO ... .'''
+
+    @wraps(method)
+    def end_with_display_or_return_logic(self, *args, **kwargs):
+        '''A wrapper for TODO ... .'''
+        string = method(self, *args, **kwargs)
+
+        # display=True is always default, so if display not provided, set True
+        display = kwargs.get('display', True)
+
+        if display:
+            print(string)
+        else:
+            return string
+
+    return end_with_display_or_return_logic

--- a/cfdm/domain.py
+++ b/cfdm/domain.py
@@ -5,7 +5,8 @@ from . import core
 
 from . import Constructs
 
-from .decorators import _manage_log_level_via_verbosity
+from .decorators import (_manage_log_level_via_verbosity,
+                         _display_or_return)
 
 
 logger = logging.getLogger(__name__)
@@ -154,6 +155,7 @@ class Domain(mixin.ConstructAccess,
 
         return '\n'.join(string)
 
+    @_display_or_return
     def _dump_axes(self, axis_names, display=True, _level=0):
         '''Return a string containing a description of the domain axes of the
     field.
@@ -181,13 +183,9 @@ class Domain(mixin.ConstructAccess,
         w = sorted(["{0}Domain Axis: {1}".format(indent1, axis_names[axis])
                     for axis in axes])
 
-        string = '\n'.join(w)
+        return '\n'.join(w)
 
-        if display:
-            print(string)
-        else:
-            return string
-
+    @_display_or_return
     def dump(self, display=True, _level=0, _title=None):
         '''A full description of the domain.
 
@@ -285,12 +283,7 @@ class Domain(mixin.ConstructAccess,
 
         string.append('')
 
-        string = '\n'.join(string)
-
-        if display:
-            print(string)
-        else:
-            return string
+        return '\n'.join(string)
 
     @_manage_log_level_via_verbosity
     def equals(self, other, rtol=None, atol=None, verbose=None,

--- a/cfdm/field.py
+++ b/cfdm/field.py
@@ -22,6 +22,7 @@ from .decorators import (
     _inplace_enabled_define_and_cleanup,
     _manage_log_level_via_verbosity,
     _test_decorator_args,
+    _display_or_return,
 )
 
 
@@ -1493,6 +1494,7 @@ class Field(mixin.NetCDFVariable,
 
         return out
 
+    @_display_or_return
     def dump(self, display=True, _level=0, _title=None):
         '''A full description of the field construct.
 
@@ -1582,12 +1584,7 @@ class Field(mixin.NetCDFVariable,
 
         string.append(self.get_domain().dump(display=False))
 
-        string = '\n'.join(string)
-
-        if display:
-            print(string)
-        else:
-            return string
+        return '\n'.join(string)
 
     @_manage_log_level_via_verbosity
     def equals(self, other, rtol=None, atol=None, verbose=None,

--- a/cfdm/mixin/properties.py
+++ b/cfdm/mixin/properties.py
@@ -5,7 +5,8 @@ import numpy
 
 from . import Container
 
-from ..decorators import _manage_log_level_via_verbosity
+from ..decorators import (_manage_log_level_via_verbosity,
+                          _display_or_return)
 
 
 logger = logging.getLogger(__name__)
@@ -153,6 +154,7 @@ class Properties(Container):
 
         return out
 
+    @_display_or_return
     def dump(self, display=True, _key=None, _omit_properties=(),
              _prefix='', _title=None, _create_title=True, _level=0):
         '''A full description.
@@ -202,12 +204,7 @@ class Properties(Container):
         if properties:
             string.append(properties)
 
-        string = '\n'.join(string)
-
-        if display:
-            print(string)
-        else:
-            return string
+        return '\n'.join(string)
 
     @_manage_log_level_via_verbosity
     def equals(self, other, rtol=None, atol=None, verbose=None,

--- a/cfdm/mixin/propertiesdata.py
+++ b/cfdm/mixin/propertiesdata.py
@@ -5,6 +5,7 @@ from ..data import Data
 from . import Properties
 
 from ..decorators import (
+    _display_or_return,
     _inplace_enabled,
     _inplace_enabled_define_and_cleanup,
     _manage_log_level_via_verbosity,
@@ -545,6 +546,7 @@ class PropertiesData(Properties):
 
         return out
 
+    @_display_or_return
     def dump(self, display=True, _key=None, _omit_properties=(),
              _prefix='', _title=None, _create_title=True, _level=0,
              _axes=None, _axis_names=None):
@@ -599,12 +601,7 @@ class PropertiesData(Properties):
                                                          shape,
                                                          str(data)))
 
-        string = '\n'.join(string)
-
-        if display:
-            print(string)
-        else:
-            return string
+        return '\n'.join(string)
 
     @_manage_log_level_via_verbosity
     def equals(self, other, rtol=None, atol=None, verbose=None,

--- a/cfdm/mixin/propertiesdatabounds.py
+++ b/cfdm/mixin/propertiesdatabounds.py
@@ -8,6 +8,7 @@ from . import PropertiesData
 from ..functions import rtol, atol
 
 from ..decorators import (
+    _display_or_return,
     _inplace_enabled,
     _inplace_enabled_define_and_cleanup,
     _manage_log_level_via_verbosity,
@@ -742,6 +743,7 @@ class PropertiesDataBounds(PropertiesData):
                 "{!r} has no part node count variable".format(
                     self.__class__.__name__))
 
+    @_display_or_return
     def dump(self, display=True, _key=None, _omit_properties=None,
              _prefix='', _title=None, _create_title=True, _level=0,
              _axes=None, _axis_names=None):
@@ -802,12 +804,7 @@ class PropertiesDataBounds(PropertiesData):
                 _level=_level, _axes=_axes,
                 _axis_names=_axis_names))
 
-        string = '\n'.join(string)
-
-        if display:
-            print(string)
-        else:
-            return string
+        return '\n'.join(string)
 
     @_manage_log_level_via_verbosity
     def equals(self, other, rtol=None, atol=None, verbose=None,


### PR DESCRIPTION
Closes #96, including adding a test for this new decorator which I have called `_display_or_return`, where I have used `@unittest.mock.patch('builtins.print')` to explicitly check that any case that should print something does indeed print it, as well as checking for (lack of) output.