### PR TITLE
Allow functions to be decorated with via_verbosity

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -103,7 +103,7 @@ jobs:
       # would have to run anyway, it is simplest to add it in this flow.
       # Also, it means code coverage is only generated if the test suite is
       # passing at least for that job, avoiding useless coverage reports.
-      uses: codecov/codecov-action@v1.0.13
+      uses: codecov/codecov-action@v1
       if: |
         matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7
       with:

--- a/cfdm/decorators.py
+++ b/cfdm/decorators.py
@@ -130,9 +130,12 @@ def _manage_log_level_via_verbosity(method_with_verbose_kwarg, calls=[0]):
     concern) that this approach may not be thread-safe.
 
     '''
+    # Note that 'self' can be included in '*args' for any function calls
+    # below, such that this decorator will work for both methods and
+    # functions that are not bound to classes.
 
     @wraps(method_with_verbose_kwarg)
-    def verbose_override_wrapper(self, *args, **kwargs):
+    def verbose_override_wrapper(*args, **kwargs):
         # Increment indicates that one decorated function has started
         # execution
         calls[0] += 1
@@ -183,7 +186,7 @@ def _manage_log_level_via_verbosity(method_with_verbose_kwarg, calls=[0]):
         # After method completes, re-set any changes to log level or
         # enabling
         try:
-            return method_with_verbose_kwarg(self, *args, **kwargs)
+            return method_with_verbose_kwarg(*args, **kwargs)
         except Exception:
             raise
         finally:  # so that crucial 'teardown' code runs even if


### PR DESCRIPTION
The `_manage_log_level_via_verbosity` decorator was only applicable and functioning for use on methods, not for functions not bound to classes, but there are a number of cases of the latter in both `cfdm` and `cf` where we want to apply it. This PR:

* confirms the above via extending the decorator unit test so there is failure when it is applied to a function; &
* generalises the decorator so it can be used in any case, fixing the new test failures (this was easy as `self` can be included in the `*args` already included in the calls, so I just had to remove the explicit reference to `self`).

