### PR TITLE
Enable faulthandler for all test modules

### DIFF
--- a/cfdm/test/create_test_files.py
+++ b/cfdm/test/create_test_files.py
@@ -3,6 +3,10 @@ import os
 import unittest
 
 import numpy
+
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import netCDF4
 
 import cfdm

--- a/cfdm/test/run_tests.py
+++ b/cfdm/test/run_tests.py
@@ -4,6 +4,9 @@ import unittest
 
 from random import choice, shuffle
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/setup_create_field.py
+++ b/cfdm/test/setup_create_field.py
@@ -4,6 +4,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/setup_create_field_2.py
+++ b/cfdm/test/setup_create_field_2.py
@@ -4,6 +4,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 verbose = False

--- a/cfdm/test/setup_create_field_3.py
+++ b/cfdm/test/setup_create_field_3.py
@@ -4,6 +4,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_AuxiliaryCoordinate.py
+++ b/cfdm/test/test_AuxiliaryCoordinate.py
@@ -4,6 +4,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_CFDMImplementation.py
+++ b/cfdm/test/test_CFDMImplementation.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_CellMeasure.py
+++ b/cfdm/test/test_CellMeasure.py
@@ -5,6 +5,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_CellMethod.py
+++ b/cfdm/test/test_CellMethod.py
@@ -5,6 +5,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_Constructs.py
+++ b/cfdm/test/test_Constructs.py
@@ -6,6 +6,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_CoordinateReference.py
+++ b/cfdm/test/test_CoordinateReference.py
@@ -7,6 +7,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_Count.py
+++ b/cfdm/test/test_Count.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_Data.py
+++ b/cfdm/test/test_Data.py
@@ -5,8 +5,10 @@ import itertools
 import os
 import unittest
 
-
 import numpy
+
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
 

--- a/cfdm/test/test_DimensionCoordinate.py
+++ b/cfdm/test/test_DimensionCoordinate.py
@@ -4,6 +4,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_Domain.py
+++ b/cfdm/test/test_Domain.py
@@ -5,6 +5,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_DomainAncillary.py
+++ b/cfdm/test/test_DomainAncillary.py
@@ -4,6 +4,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_DomainAxis.py
+++ b/cfdm/test/test_DomainAxis.py
@@ -5,6 +5,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_Field.py
+++ b/cfdm/test/test_Field.py
@@ -9,7 +9,11 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
+
 
 n_tmpfiles = 1
 tmpfiles = [tempfile.mkstemp('_test_Field.nc', dir=os.getcwd())[1]

--- a/cfdm/test/test_FieldAncillary.py
+++ b/cfdm/test/test_FieldAncillary.py
@@ -4,6 +4,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_Index.py
+++ b/cfdm/test/test_Index.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_InteriorRing.py
+++ b/cfdm/test/test_InteriorRing.py
@@ -2,6 +2,9 @@ import datetime
 import os
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_List.py
+++ b/cfdm/test/test_List.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_NodeCountProperties.py
+++ b/cfdm/test/test_NodeCountProperties.py
@@ -2,6 +2,9 @@ import datetime
 import os
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_NumpyArray.py
+++ b/cfdm/test/test_NumpyArray.py
@@ -3,6 +3,9 @@ import copy
 import numpy
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_PartNodeCountProperties.py
+++ b/cfdm/test/test_PartNodeCountProperties.py
@@ -2,6 +2,9 @@ import datetime
 import os
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_RaggedContiguousArray.py
+++ b/cfdm/test/test_RaggedContiguousArray.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_RaggedIndexedArray.py
+++ b/cfdm/test/test_RaggedIndexedArray.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_RaggedIndexedContiguousArray.py
+++ b/cfdm/test/test_RaggedIndexedContiguousArray.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_core_1.py
+++ b/cfdm/test/test_core_1.py
@@ -3,6 +3,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 verbose = False

--- a/cfdm/test/test_decorators.py
+++ b/cfdm/test/test_decorators.py
@@ -2,10 +2,12 @@ import copy
 import datetime
 import itertools
 import unittest
+from unittest.mock import patch
+
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
-from unittest.mock import patch
 
 
 # Note: it is important we test on the cfdm logging config rather than the

--- a/cfdm/test/test_docstring.py
+++ b/cfdm/test/test_docstring.py
@@ -2,6 +2,9 @@ import datetime
 import inspect
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_dsg.py
+++ b/cfdm/test/test_dsg.py
@@ -5,6 +5,10 @@ import tempfile
 import unittest
 
 import numpy
+
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import netCDF4
 
 import cfdm

--- a/cfdm/test/test_external.py
+++ b/cfdm/test/test_external.py
@@ -4,8 +4,12 @@ import os
 import tempfile
 import unittest
 
-import netCDF4
 import numpy
+
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
+import netCDF4
 
 import cfdm
 

--- a/cfdm/test/test_functions.py
+++ b/cfdm/test/test_functions.py
@@ -11,6 +11,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_gathering.py
+++ b/cfdm/test/test_gathering.py
@@ -4,8 +4,12 @@ import os
 import tempfile
 import unittest
 
-import netCDF4
 import numpy
+
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
+import netCDF4
 
 import cfdm
 

--- a/cfdm/test/test_geometry.py
+++ b/cfdm/test/test_geometry.py
@@ -6,6 +6,10 @@ import tempfile
 import unittest
 
 import numpy
+
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import netCDF4
 
 import cfdm

--- a/cfdm/test/test_groups.py
+++ b/cfdm/test/test_groups.py
@@ -4,6 +4,9 @@ import os
 import tempfile
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import netCDF4
 
 import cfdm

--- a/cfdm/test/test_netCDF.py
+++ b/cfdm/test/test_netCDF.py
@@ -5,6 +5,9 @@ import os
 import tempfile
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -9,6 +9,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 warnings = False

--- a/cfdm/test/test_string.py
+++ b/cfdm/test/test_string.py
@@ -7,6 +7,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 

--- a/cfdm/test/test_style.py
+++ b/cfdm/test/test_style.py
@@ -3,6 +3,9 @@ import os
 import pycodestyle
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cfdm
 
 


### PR DESCRIPTION
See description to NCAS-CMS/cf-python#179 which this PR is equivalent to, but for cfdm.