### PR TITLE
Improve handling of constructs by `Field.convert`

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,12 @@
+version 1.8.?.?
+---------------
+----
+
+**2021-??-??**
+
+* Construct access API changes from 1.8.9.0 applied to `Field.convert`
+* Improved error message for invalid inputs to `Field.convert`
+
 version 1.8.9.0
 ---------------
 ----

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -264,6 +264,11 @@ class CFDMImplementation(Implementation):
     def convert(self, field=None, construct_id=None):
         """Convert a metadata construct into a field construct.
 
+        Only metadata constructs that can have data may be converted
+        and they can be converted even if they do not actually have
+        any data. Constructs such as cell methods which cannot have
+        data cannot be converted.
+
         :Parameters:
 
             field: field construct

--- a/cfdm/field.py
+++ b/cfdm/field.py
@@ -1947,6 +1947,11 @@ class Field(
         constructs (such as dimension coordinate and coordinate
         reference constructs) that define its domain.
 
+        Only metadata constructs that can have data may be converted
+        and they can be converted even if they do not actually have
+        any data. Constructs such as cell methods which cannot have
+        data cannot be converted.
+
         The `{{package}}.read` function allows a field construct to be
         derived directly from a netCDF variable that corresponds to a
         metadata construct. In this case, the new field construct will
@@ -2022,6 +2027,10 @@ class Field(
         if c is None:
             raise ValueError("Can't return zero constructs")
 
+        if not hasattr(c, "has_data"):  # i.e. a construct that never has data
+            raise ValueError(
+                "Can't convert a construct that does not have data"
+            )
         # ------------------------------------------------------------
         # Create a new field with the properties and data from the
         # construct

--- a/cfdm/field.py
+++ b/cfdm/field.py
@@ -1938,7 +1938,7 @@ class Field(
 
         return f
 
-    def convert(self, key, full_domain=True):
+    def convert(self, *identity, full_domain=True, **filter_kwargs):
         """Convert a metadata construct into a new field construct.
 
         The new field construct has the properties and data of the
@@ -1967,7 +1967,7 @@ class Field(
 
         :Parameters:
 
-            key: `str`
+            identity: `str`, optional
                 Convert the metadata construct with the given
                 construct key.
 
@@ -1976,6 +1976,10 @@ class Field(
                 the domain of the new field construct. By default as
                 much of the domain as possible is copied to the new
                 field construct.
+
+            {{filter_kwargs: optional}} Also to configure the returned value.
+
+                 .. versionadded:: (cfdm) 1.8.9.0
 
         :Returns:
 
@@ -2023,7 +2027,7 @@ class Field(
         Data            : surface_altitude(grid_latitude(10), grid_longitude(9)) m
 
         """
-        c = self.constructs.get(key)
+        c = self.constructs.get(*identity, **filter_kwargs)
         if c is None:
             raise ValueError("Can't return zero constructs")
 
@@ -2044,7 +2048,7 @@ class Field(
         # Add domain axes
         # ------------------------------------------------------------
         constructs_data_axes = self.constructs.data_axes()
-        data_axes = constructs_data_axes.get(key)
+        data_axes = constructs_data_axes.get(*identity, **filter_kwargs)
         if data_axes is not None:
             domain_axes = self.domain_axes(todict=True)
             for domain_axis in data_axes:

--- a/cfdm/test/test_Field.py
+++ b/cfdm/test/test_Field.py
@@ -436,6 +436,12 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             f.convert("qwerty")
 
+        # Test some constructs which can never have data
+        with self.assertRaises(ValueError):
+            f.convert("cellmethod0")
+        with self.assertRaises(ValueError):
+            f.convert("domainaxis0")
+
     def test_Field_equals(self):
         """TODO DOCS."""
         f = self.f1


### PR DESCRIPTION
Update the `Field.convert` method to:

* provide a better error message and clarify in the docstring that only metadata construct inputs that *can* have data (i.e. are able to, but if they don't that's okay, opposed to ones that can't ever) can be converted i.e. are valid; and
* apply the new (v1.8.9.0) API for construct selection (see #132) since this method seems to have been missed with that update.