### PR TITLE
Complete docstring TODOs, removing duplication

### DIFF
--- a/cfdm/test/create_test_files.py
+++ b/cfdm/test/create_test_files.py
@@ -20,7 +20,7 @@ VN = cfdm.CF()
 # DSG files
 # --------------------------------------------------------------------
 def _make_contiguous_file(filename):
-    """TODO DOCS."""
+    """Make a netCDF file with a contiguous ragged array DSG feature."""
     n = netCDF4.Dataset(filename, "w", format="NETCDF3_CLASSIC")
 
     n.Conventions = "CF-" + VN
@@ -112,7 +112,7 @@ def _make_contiguous_file(filename):
 
 
 def _make_indexed_file(filename):
-    """TODO DOCS."""
+    """Make a netCDF file with an indexed ragged array DSG feature."""
     n = netCDF4.Dataset(filename, "w", format="NETCDF3_CLASSIC")
 
     n.Conventions = "CF-" + VN
@@ -245,7 +245,7 @@ def _make_indexed_file(filename):
 
 
 def _make_indexed_contiguous_file(filename):
-    """TODO DOCS."""
+    """Make a netCDF file with an indexed contiguous ragged array."""
     n = netCDF4.Dataset(filename, "w", format="NETCDF3_CLASSIC")
 
     n.Conventions = "CF-" + VN
@@ -625,7 +625,7 @@ indexed_contiguous_file = _make_indexed_contiguous_file(
 # External variable files
 # --------------------------------------------------------------------
 def _make_external_files():
-    """TODO DOCS."""
+    """Make netCDF files with external variables."""
 
     def _pp(
         filename,
@@ -634,7 +634,7 @@ def _make_external_files():
         combined=False,
         external_missing=False,
     ):
-        """TODO DOCS."""
+        """Make a netCDF file with some external variables."""
         nc = netCDF4.Dataset(filename, "w", format="NETCDF3_CLASSIC")
 
         nc.createDimension("grid_latitude", 10)
@@ -730,10 +730,10 @@ def _make_external_files():
 # Gathered files
 # --------------------------------------------------------------------
 def _make_gathered_file(filename):
-    """TODO DOCS."""
+    """Make a netCDF file with a gathered array."""
 
     def _jj(shape, list_values):
-        """TODO DOCS."""
+        """Create and return a gathered array."""
         array = numpy.ma.masked_all(shape)
         for i, (index, x) in enumerate(numpy.ndenumerate(array)):
             if i in list_values:

--- a/cfdm/test/setup_create_field.py
+++ b/cfdm/test/setup_create_field.py
@@ -16,7 +16,7 @@ warnings = False
 
 
 class create_fieldTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Test ab initio creation of field constructs in memory."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -39,7 +39,7 @@ class create_fieldTest(unittest.TestCase):
             pass
 
     def test_create_field(self):
-        """TODO DOCS."""
+        """Test ab initio creation of a first variation of field."""
         # Dimension coordinates
         dim1 = cfdm.DimensionCoordinate(data=cfdm.Data(numpy.arange(10.0)))
         dim1.set_property("standard_name", "grid_latitude")

--- a/cfdm/test/setup_create_field.py
+++ b/cfdm/test/setup_create_field.py
@@ -19,7 +19,7 @@ class create_fieldTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or calls (those

--- a/cfdm/test/setup_create_field_2.py
+++ b/cfdm/test/setup_create_field_2.py
@@ -15,7 +15,7 @@ warnings = False
 
 
 class create_fieldTest_2(unittest.TestCase):
-    """TODO DOCS."""
+    """Test ab initio creation of field constructs in memory."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -34,7 +34,7 @@ class create_fieldTest_2(unittest.TestCase):
         )
 
     def test_create_field_2(self):
-        """TODO DOCS."""
+        """Test ab initio creation of a second variation of field."""
         # Dimension coordinates
         dim1 = cfdm.DimensionCoordinate(data=cfdm.Data(numpy.arange(10.0)))
         dim1.set_property("standard_name", "projection_y_coordinate")

--- a/cfdm/test/setup_create_field_2.py
+++ b/cfdm/test/setup_create_field_2.py
@@ -18,7 +18,7 @@ class create_fieldTest_2(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.LOG_LEVEL("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/setup_create_field_3.py
+++ b/cfdm/test/setup_create_field_3.py
@@ -19,7 +19,7 @@ class create_fieldTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.LOG_LEVEL("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/setup_create_field_3.py
+++ b/cfdm/test/setup_create_field_3.py
@@ -16,7 +16,7 @@ warnings = False
 
 
 class create_fieldTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Test ab initio creation of field constructs in memory."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -36,7 +36,7 @@ class create_fieldTest(unittest.TestCase):
         )
 
     def test_create_field_3(self):
-        """TODO DOCS."""
+        """Test ab initio creation of a third variation of field."""
         # Dimension coordinates
         data = numpy.arange(9.0) + 20
         data[-1] = 34

--- a/cfdm/test/test_AuxiliaryCoordinate.py
+++ b/cfdm/test/test_AuxiliaryCoordinate.py
@@ -76,7 +76,7 @@ class AuxiliaryCoordinateTest(unittest.TestCase):
         cfdm.AuxiliaryCoordinate(bounds=d)
 
     def test_AuxiliaryCoordinate_properties(self):
-        """TODO DOCS."""
+        """Test the property access methods of AuxiliaryCoordinate."""
         f = cfdm.read(self.filename)[0]
         x = f.auxiliary_coordinates("latitude").value()
 
@@ -94,7 +94,7 @@ class AuxiliaryCoordinateTest(unittest.TestCase):
         cfdm.AuxiliaryCoordinate(source=d)
 
     def test_AuxiliaryCoordinate_insert_dimension(self):
-        """TODO DOCS."""
+        """Test the `insert_dimension` method of AuxiliaryCoordinate."""
         f = cfdm.read(self.filename)[0]
         d = f.dimension_coordinates("grid_longitude").value()
         x = cfdm.AuxiliaryCoordinate(source=d)
@@ -111,7 +111,7 @@ class AuxiliaryCoordinateTest(unittest.TestCase):
         self.assertEqual(x.bounds.shape, (9, 1, 2), x.bounds.shape)
 
     def test_AuxiliaryCoordinate_transpose(self):
-        """TODO DOCS."""
+        """Test the transpose method of AuxiliaryCoordinate."""
         f = cfdm.read(self.filename)[0]
         x = f.auxiliary_coordinates("longitude").value()
 
@@ -132,7 +132,7 @@ class AuxiliaryCoordinateTest(unittest.TestCase):
         self.assertEqual(x.bounds.shape, (10, 9, 4), x.bounds.shape)
 
     def test_AuxiliaryCoordinate_squeeze(self):
-        """TODO DOCS."""
+        """Test the squeeze method of AuxiliaryCoordinate."""
         f = cfdm.read(self.filename)[0]
         x = f.auxiliary_coordinates("longitude").value()
 
@@ -155,7 +155,7 @@ class AuxiliaryCoordinateTest(unittest.TestCase):
         self.assertEqual(x.bounds.shape, (1, 9, 10, 4), x.bounds.shape)
 
     def test_AuxiliaryCoordinate_interior_ring(self):
-        """TODO DOCS."""
+        """Test the interior ring access AuxiliaryCoordinate methods."""
         c = cfdm.AuxiliaryCoordinate()
 
         i = cfdm.InteriorRing(data=cfdm.Data(numpy.arange(10).reshape(5, 2)))

--- a/cfdm/test/test_AuxiliaryCoordinate.py
+++ b/cfdm/test/test_AuxiliaryCoordinate.py
@@ -46,7 +46,7 @@ class AuxiliaryCoordinateTest(unittest.TestCase):
     aux1.set_bounds(bounds)
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_AuxiliaryCoordinate.py
+++ b/cfdm/test/test_AuxiliaryCoordinate.py
@@ -73,7 +73,7 @@ class AuxiliaryCoordinateTest(unittest.TestCase):
         f = cfdm.read(self.filename)[0]
 
         d = f.dimension_coordinates("grid_longitude").value()
-        cfdm.AuxiliaryCoordinate(source=d)
+        cfdm.AuxiliaryCoordinate(bounds=d)
 
     def test_AuxiliaryCoordinate_properties(self):
         """TODO DOCS."""

--- a/cfdm/test/test_AuxiliaryCoordinate.py
+++ b/cfdm/test/test_AuxiliaryCoordinate.py
@@ -59,7 +59,7 @@ class AuxiliaryCoordinateTest(unittest.TestCase):
         # cfdm.log_level('DISABLE')
 
     def test_AuxiliaryCoordinate__repr__str__dump(self):
-        """TODO DOCS."""
+        """Test all means of AuxiliaryCoordinate inspection."""
         f = cfdm.read(self.filename, verbose=1)[0]
         x = f.auxiliary_coordinates("latitude").value()
 

--- a/cfdm/test/test_AuxiliaryCoordinate.py
+++ b/cfdm/test/test_AuxiliaryCoordinate.py
@@ -69,7 +69,7 @@ class AuxiliaryCoordinateTest(unittest.TestCase):
         self.assertIsInstance(x.dump(display=False, _title=None), str)
 
     def test_AuxiliaryCoordinate_bounds(self):
-        """TODO DOCS."""
+        """Test the bounds keyword argument to AuxiliaryCoordinate."""
         f = cfdm.read(self.filename)[0]
 
         d = f.dimension_coordinates("grid_longitude").value()
@@ -88,7 +88,7 @@ class AuxiliaryCoordinateTest(unittest.TestCase):
         self.assertIsNone(x.del_property("long_name", None))
 
     def test_AuxiliaryCoordinate_source(self):
-        """TODO DOCS."""
+        """Test the source keyword argument to AuxiliaryCoordinate."""
         f = cfdm.read(self.filename)[0]
         d = f.dimension_coordinates("grid_longitude").value()
         cfdm.AuxiliaryCoordinate(source=d)

--- a/cfdm/test/test_AuxiliaryCoordinate.py
+++ b/cfdm/test/test_AuxiliaryCoordinate.py
@@ -12,7 +12,7 @@ import cfdm
 
 
 class AuxiliaryCoordinateTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the AuxiliaryCoordinate class."""
 
     filename = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "test_file.nc"

--- a/cfdm/test/test_CFDMImplementation.py
+++ b/cfdm/test/test_CFDMImplementation.py
@@ -9,7 +9,7 @@ import cfdm
 
 
 class CFDMImplementationTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the CFDMImplementation class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_CFDMImplementation.py
+++ b/cfdm/test/test_CFDMImplementation.py
@@ -12,7 +12,7 @@ class CFDMImplementationTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or calls (those

--- a/cfdm/test/test_CFDMImplementation.py
+++ b/cfdm/test/test_CFDMImplementation.py
@@ -24,19 +24,19 @@ class CFDMImplementationTest(unittest.TestCase):
         self.i = cfdm.implementation()
 
     def test_CFDMImplementation__init__(self):
-        """TODO DOCS."""
+        """Test the constructor of CFDMImplementation."""
         cfdm.CFDMImplementation({"NewClass1": "qwerty", "NewClass2": None})
 
     def test_CFDMImplementation_classes(self):
-        """TODO DOCS."""
+        """Test the classes method of CFDMImplementation."""
         self.assertIsInstance(self.i.classes(), dict)
 
     def test_CFDMImplementation_set_class(self):
-        """TODO DOCS."""
+        """Test the `set_class` method of CFDMImplementation."""
         self.i.set_class("NewClass", "qwerty")
 
     def test_CFDMImplementation_get_class(self):
-        """TODO DOCS."""
+        """Test the `get_class` method of CFDMImplementation."""
         self.assertIs(self.i.get_class("Field"), cfdm.Field)
 
         with self.assertRaises(ValueError):

--- a/cfdm/test/test_CellMeasure.py
+++ b/cfdm/test/test_CellMeasure.py
@@ -10,7 +10,7 @@ import cfdm
 
 
 class CellMeasureTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the CellMeasure class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_CellMeasure.py
+++ b/cfdm/test/test_CellMeasure.py
@@ -13,7 +13,7 @@ class CellMeasureTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.LOG_LEVEL("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_CellMeasure.py
+++ b/cfdm/test/test_CellMeasure.py
@@ -33,7 +33,7 @@ class CellMeasureTest(unittest.TestCase):
         self.f = f[0]
 
     def test_CellMeasure__init__(self):
-        """TODO DOCS."""
+        """Test the CellMeasure constructor and source keyword."""
         cfdm.CellMeasure(source="qwerty")
 
     def test_CellMeasure__repr__str__dump_construct_type(self):
@@ -47,7 +47,7 @@ class CellMeasureTest(unittest.TestCase):
             self.assertEqual(cm.construct_type, "cell_measure")
 
     def test_CellMeasure(self):
-        """TODO DOCS."""
+        """Test measure access and (un)setting CellMeasure methods."""
         f = self.f.copy()
 
         cm = f.construct("measure:area")

--- a/cfdm/test/test_CellMeasure.py
+++ b/cfdm/test/test_CellMeasure.py
@@ -37,7 +37,7 @@ class CellMeasureTest(unittest.TestCase):
         cfdm.CellMeasure(source="qwerty")
 
     def test_CellMeasure__repr__str__dump_construct_type(self):
-        """TODO DOCS."""
+        """Test all means of CellMeasure inspection."""
         f = self.f
 
         for cm in f.cell_measures().values():

--- a/cfdm/test/test_CellMethod.py
+++ b/cfdm/test/test_CellMethod.py
@@ -41,11 +41,11 @@ class CellMethodTest(unittest.TestCase):
             self.assertEqual(c.construct_type, "cell_method")
 
     def test_CellMethod(self):
-        """TODO DOCS."""
+        """Test CellMethod equality, identity and sorting methods."""
         f = self.f
 
         # ------------------------------------------------------------
-        # Equals and idenities
+        # Equals and identities
         # ------------------------------------------------------------
         for c in f.cell_methods().values():
             d = c.copy()
@@ -92,7 +92,7 @@ class CellMethodTest(unittest.TestCase):
         c = cfdm.CellMethod(source="qwerty")
 
     def test_CellMethod_axes(self):
-        """TODO DOCS."""
+        """Test the axes access and (un)setting CellMethod methods."""
         f = cfdm.CellMethod()
 
         self.assertFalse(f.has_axes())
@@ -104,7 +104,7 @@ class CellMethodTest(unittest.TestCase):
         self.assertIsNone(f.del_axes(None))
 
     def test_CellMethod_method(self):
-        """TODO DOCS."""
+        """Test the method access and (un)setting CellMethod methods."""
         f = cfdm.CellMethod()
 
         self.assertFalse(f.has_method())
@@ -116,7 +116,7 @@ class CellMethodTest(unittest.TestCase):
         self.assertIsNone(f.del_method(None))
 
     def test_CellMethod_qualifier(self):
-        """TODO DOCS."""
+        """Test qualifier access and (un)setting CellMethod methods."""
         f = cfdm.CellMethod()
 
         self.assertEqual(f.qualifiers(), {})

--- a/cfdm/test/test_CellMethod.py
+++ b/cfdm/test/test_CellMethod.py
@@ -10,7 +10,7 @@ import cfdm
 
 
 class CellMethodTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the CellMethod class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_CellMethod.py
+++ b/cfdm/test/test_CellMethod.py
@@ -13,7 +13,7 @@ class CellMethodTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or calls (those

--- a/cfdm/test/test_CellMethod.py
+++ b/cfdm/test/test_CellMethod.py
@@ -31,7 +31,7 @@ class CellMethodTest(unittest.TestCase):
         self.f = f[0]
 
     def test_CellMethod__repr__str__dump_construct_type(self):
-        """TODO DOCS."""
+        """Test all means of CellMethod inspection."""
         f = self.f
 
         for c in f.cell_methods().values():

--- a/cfdm/test/test_Constructs.py
+++ b/cfdm/test/test_Constructs.py
@@ -11,7 +11,7 @@ import cfdm
 
 
 class ConstructsTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the Constructs class."""
 
     f = cfdm.example_field(1)
     c = f.constructs

--- a/cfdm/test/test_Constructs.py
+++ b/cfdm/test/test_Constructs.py
@@ -40,31 +40,31 @@ class ConstructsTest(unittest.TestCase):
         str(c)
 
     def test_Constructs__len__(self):
-        """TODO DOCS."""
+        """Test the length returned for Constructs."""
         c = self.c
 
         self.assertEqual(len(c), 20)
         self.assertEqual(len(self.f.domain.constructs), 17)
 
     def test_Constructs_check_construct_type(self):
-        """TODO DOCS."""
+        """Test the `check_construct_type` Constructs method."""
         c = self.c
 
         with self.assertRaises(ValueError):
             c._check_construct_type("bad type")
 
     def test_Constructs_construct_type(self):
-        """TODO DOCS."""
+        """Test the `construct_type` Constructs method."""
         d = self.f.domain.constructs
         self.assertIsNone(d.construct_type("cell_method"))
 
     def test_Constructs_construct_types(self):
-        """TODO DOCS."""
+        """Test the `construct_types` Constructs method."""
         d = self.f.domain.constructs
         self.assertEqual(len(d.construct_types()), len(d))
 
     def test_Constructs_items_key_value(self):
-        """TODO DOCS."""
+        """Test the items, key and value Constructs methods."""
         c = self.c
 
         for i, (key, value) in enumerate(c.items()):
@@ -75,7 +75,7 @@ class ConstructsTest(unittest.TestCase):
         self.assertEqual(i, 19)
 
     def test_Constructs_copy_shallow_copy(self):
-        """TODO DOCS."""
+        """Test the Constructs methods for copying."""
         c = self.c
 
         d = c.filter_by_type("domain_axis")
@@ -88,14 +88,14 @@ class ConstructsTest(unittest.TestCase):
         self.assertTrue(d.equals(c, verbose=3))
 
     def test_Constructs_domain_axis_identity(self):
-        """TODO DOCS."""
+        """Test the `domain_axis_identity` Constructs method."""
         c = self.c
 
         with self.assertRaises(ValueError):
             c.domain_axis_identity(999)
 
     def test_Constructs_filter(self):
-        """TODO DOCS."""
+        """Trivial test of constructs-filtering Constructs methods."""
         c = self.c
 
         for todict in (False, True):
@@ -123,7 +123,7 @@ class ConstructsTest(unittest.TestCase):
             c.filter(bad_kwarg=None)
 
     def test_Constructs_FILTERING(self):
-        """TODO DOCS."""
+        """Test Constructs methods that invert or reverse filters."""
         c = self.c
 
         # Axis
@@ -170,7 +170,7 @@ class ConstructsTest(unittest.TestCase):
         self.assertTrue(c.unfilter(1).equals(c, verbose=3))
 
     def test_Constructs_domain_axes(self):
-        """TODO DOCS."""
+        """Test the `domain_axes` Constructs method."""
         c = self.c
 
         self.assertEqual(c.domain_axes(cached=999), 999)
@@ -191,14 +191,14 @@ class ConstructsTest(unittest.TestCase):
             )
 
     def test_Constructs_filter_by_data(self):
-        """TODO DOCS."""
+        """Test the `filter_by_data` Constructs method."""
         c = self.c
 
         self.assertEqual(len(c.filter_by_data()), 12)
         self.assertEqual(c.filter_by_data(cached=999), 999)
 
     def test_Constructs_filter_by_type(self):
-        """TODO DOCS."""
+        """Test the `filter_by_type` Constructs method."""
         c = self.c
 
         self.assertEqual(c.filter_by_type(cached=999), 999)
@@ -284,7 +284,7 @@ class ConstructsTest(unittest.TestCase):
         self.assertEqual(len(c.filter_by_type("qwerty")), 0)
 
     def test_Constructs_filter_by_method(self):
-        """TODO DOCS."""
+        """Test the `filter_by_method` Constructs method."""
         c = self.c
 
         self.assertEqual(len(c.filter_by_method()), 2)
@@ -293,7 +293,7 @@ class ConstructsTest(unittest.TestCase):
         self.assertEqual(c.filter_by_method(cached=999), 999)
 
     def test_Constructs_filter_by_ncdim(self):
-        """TODO DOCS."""
+        """Test the `filter_by_ncdim` Constructs method."""
         c = self.c
 
         self.assertEqual(len(c.filter_by_ncdim()), 4)
@@ -302,7 +302,7 @@ class ConstructsTest(unittest.TestCase):
         self.assertEqual(c.filter_by_ncdim(cached=999), 999)
 
     def test_Constructs_filter_by_ncvar(self):
-        """TODO DOCS."""
+        """Test the `filter_by_ncvar` Constructs method."""
         c = self.c
 
         self.assertEqual(len(c.filter_by_ncvar()), 14)
@@ -311,7 +311,7 @@ class ConstructsTest(unittest.TestCase):
         self.assertEqual(c.filter_by_ncvar(cached=999), 999)
 
     def test_Constructs_filter_by_measure(self):
-        """TODO DOCS."""
+        """Test the `filter_by_measure` Constructs method."""
         c = self.c
 
         self.assertEqual(len(c.filter_by_measure()), 1)
@@ -320,7 +320,7 @@ class ConstructsTest(unittest.TestCase):
         self.assertEqual(c.filter_by_measure(cached=999), 999)
 
     def test_Constructs_filter_by_identity(self):
-        """TODO DOCS."""
+        """Test the `filter_by_identity` Constructs method."""
         c = self.c
 
         self.assertEqual(len(c.filter_by_identity()), 20)
@@ -336,7 +336,7 @@ class ConstructsTest(unittest.TestCase):
             c("latitude", filter_by_identity=("longitude",))
 
     def test_Constructs_filter_by_axis(self):
-        """TODO DOCS."""
+        """Test the `filter_by_axis` Constructs method."""
         c = self.c
 
         self.assertEqual(len(c.filter_by_axis()), 12)
@@ -358,14 +358,14 @@ class ConstructsTest(unittest.TestCase):
             c.filter_by_axis(0, 1, axis_mode="bad_mode")
 
     def test_Constructs_clear_filters_applied(self):
-        """TODO DOCS."""
+        """Test the `clear_filters_applied` Constructs method."""
         c = self.c
 
         d = c.shallow_copy()
         d.clear_filters_applied()
 
     def test_Constructs_filter_by_naxes(self):
-        """TODO DOCS."""
+        """Test the `filter_by_naxes` Constructs method."""
         c = self.c
 
         self.assertEqual(len(c.filter_by_naxes()), 12)
@@ -373,7 +373,7 @@ class ConstructsTest(unittest.TestCase):
         self.assertEqual(c.filter_by_naxes(cached=999), 999)
 
     def test_Constructs_filter_by_property(self):
-        """TODO DOCS."""
+        """Test the `filter_by_property` Constructs method."""
         c = self.c
 
         self.assertEqual(len(c.filter_by_property()), 12)
@@ -399,7 +399,7 @@ class ConstructsTest(unittest.TestCase):
             c.filter_by_property("bad_mode")
 
     def test_Constructs_filter_by_size(self):
-        """TODO DOCS."""
+        """Test the `filter_by_size` Constructs method."""
         c = self.c
 
         self.assertEqual(len(c.filter_by_size(9)), 1)
@@ -409,7 +409,7 @@ class ConstructsTest(unittest.TestCase):
         self.assertEqual(c.filter_by_size(cached=999), 999)
 
     def test_Constructs_filter_by_key(self):
-        """TODO DOCS."""
+        """Test the `filter_by_key` Constructs method."""
         c = self.c
 
         self.assertEqual(len(c.filter_by_key()), 20)
@@ -419,14 +419,14 @@ class ConstructsTest(unittest.TestCase):
         self.assertEqual(c.filter_by_key(cached=999), 999)
 
     def test_Constructs_copy(self):
-        """TODO DOCS."""
+        """Test the copy module copying behaviour of Constructs."""
         c = self.c
 
         copy.copy(c)
         copy.deepcopy(c)
 
     def test_Constructs__getitem__(self):
-        """TODO DOCS."""
+        """Test the lookup access of construct items from Constructs."""
         c = self.c
 
         self.assertIsInstance(
@@ -437,20 +437,20 @@ class ConstructsTest(unittest.TestCase):
             c["bad_key"]
 
     def test_Constructs_get_data_axes(self):
-        """TODO DOCS."""
+        """Test the `get_data_axes` Constructs method."""
         c = self.c
 
         with self.assertRaises(ValueError):
             c.get_data_axes("bad key")
 
     def test_Constructs_todict(self):
-        """TODO DOCS."""
+        """Test the todict Constructs method."""
         c = self.c
 
         self.assertIsInstance(c.todict(), dict)
 
     def test_Constructs_private(self):
-        """TODO DOCS."""
+        """Test internal (designated as private) Constructs methods."""
         c = self.f.domain.constructs
 
         # _construct_type_description

--- a/cfdm/test/test_Constructs.py
+++ b/cfdm/test/test_Constructs.py
@@ -30,7 +30,7 @@ class ConstructsTest(unittest.TestCase):
         # cfdm.log_level('DISABLE')
 
     def test_Constructs__repr__str__dump(self):
-        """TODO DOCS."""
+        """Test all means of Constructs inspection."""
         c = self.c
 
         repr(c)

--- a/cfdm/test/test_Constructs.py
+++ b/cfdm/test/test_Constructs.py
@@ -17,7 +17,7 @@ class ConstructsTest(unittest.TestCase):
     c = f.constructs
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.LOG_LEVEL("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_CoordinateReference.py
+++ b/cfdm/test/test_CoordinateReference.py
@@ -32,7 +32,7 @@ atexit.register(_remove_tmpfiles)
 
 
 class CoordinateReferenceTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the CoordinateReference class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_CoordinateReference.py
+++ b/cfdm/test/test_CoordinateReference.py
@@ -56,7 +56,6 @@ class CoordinateReferenceTest(unittest.TestCase):
 
     def test_CoordinateReference__repr__str__dump_construct_type(self):
         """Test all means of CoordinateReference inspection."""
-        """TODO DOCS."""
         f = self.f
 
         for cr in f.coordinate_references().values():
@@ -66,7 +65,7 @@ class CoordinateReferenceTest(unittest.TestCase):
             self.assertEqual(cr.construct_type, "coordinate_reference")
 
     def test_CoordinateReference_equals(self):
-        """TODO DOCS."""
+        """Test the equality-testing CoordinateReference method."""
         # Create a vertical grid mapping coordinate reference
         t = cfdm.CoordinateReference(
             coordinates=("coord1",),
@@ -140,7 +139,7 @@ class CoordinateReferenceTest(unittest.TestCase):
         self.assertTrue(t.equals(t.copy(), verbose=3))
 
     def test_CoordinateConversion(self):
-        """TODO DOCS."""
+        """Test a CoordinateReference coordinate conversion element."""
         f = self.f.copy()
 
         cr = f.construct("standard_name:atmosphere_hybrid_height_coordinate")
@@ -185,7 +184,7 @@ class CoordinateReferenceTest(unittest.TestCase):
         self.assertTrue(_.equals(cc))
 
     def test_Datum(self):
-        """TODO DOCS."""
+        """Test a CoordinateReference datum component."""
         f = self.f.copy()
 
         cr = f.construct("standard_name:atmosphere_hybrid_height_coordinate")

--- a/cfdm/test/test_CoordinateReference.py
+++ b/cfdm/test/test_CoordinateReference.py
@@ -55,6 +55,7 @@ class CoordinateReferenceTest(unittest.TestCase):
         self.f = f[0]
 
     def test_CoordinateReference__repr__str__dump_construct_type(self):
+        """Test all means of CoordinateReference inspection."""
         """TODO DOCS."""
         f = self.f
 

--- a/cfdm/test/test_CoordinateReference.py
+++ b/cfdm/test/test_CoordinateReference.py
@@ -35,7 +35,7 @@ class CoordinateReferenceTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.LOG_LEVEL("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_Count.py
+++ b/cfdm/test/test_Count.py
@@ -12,7 +12,7 @@ class CountTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_Count.py
+++ b/cfdm/test/test_Count.py
@@ -27,7 +27,7 @@ class CountTest(unittest.TestCase):
         self.contiguous = "DSG_timeSeries_contiguous.nc"
 
     def test_Count__repr__str__dump(self):
-        """TODO DOCS."""
+        """Test all means of Count inspection."""
         f = cfdm.read(self.contiguous)[0]
 
         count = f.data.get_count()

--- a/cfdm/test/test_Count.py
+++ b/cfdm/test/test_Count.py
@@ -9,7 +9,7 @@ import cfdm
 
 
 class CountTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the Count class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_Data.py
+++ b/cfdm/test/test_Data.py
@@ -14,7 +14,7 @@ import cfdm
 
 
 def axes_combinations(ndim):
-    """TODO DOCS."""
+    """Create axes permutations for `test_Data_flatten`."""
     return [
         axes
         for n in range(1, ndim + 1)
@@ -41,7 +41,7 @@ class DataTest(unittest.TestCase):
         )
 
     def test_Data_any(self):
-        """TODO DOCS."""
+        """Test the any Data method."""
         d = cfdm.Data([[0, 0, 0]])
         self.assertFalse(d.any())
         d[0, 0] = numpy.ma.masked
@@ -52,7 +52,7 @@ class DataTest(unittest.TestCase):
         self.assertFalse(d.any())
 
     def test_Data__repr__str(self):
-        """TODO DOCS."""
+        """Test all means of Data inspection."""
         for d in [
             cfdm.Data(9, units="km"),
             cfdm.Data([9], units="km"),
@@ -71,7 +71,7 @@ class DataTest(unittest.TestCase):
 
     #    def test_Data__getitem__(self):
     def test_Data__setitem__(self):
-        """TODO DOCS."""
+        """Test the assignment of data items on Data."""
         a = numpy.ma.arange(3000).reshape(50, 60)
 
         d = cfdm.Data(a.filled(), units="m")
@@ -134,7 +134,7 @@ class DataTest(unittest.TestCase):
         self.assertIs(a[()], numpy.ma.masked)
 
     def test_Data_apply_masking(self):
-        """TODO DOCS."""
+        """Test the `apply_masking` Data method."""
         a = numpy.ma.arange(12).reshape(3, 4)
         a[1, 1] = numpy.ma.masked
 
@@ -206,7 +206,7 @@ class DataTest(unittest.TestCase):
     #            pass
 
     def test_Data_array(self):
-        """TODO DOCS."""
+        """Test the array Data method."""
         # ------------------------------------------------------------
         # Numpy array interface (__array__)
         # ------------------------------------------------------------
@@ -248,7 +248,7 @@ class DataTest(unittest.TestCase):
         self.assertFalse((a2 == a).all())
 
     def test_Data_datetime_array(self):
-        """TODO DOCS."""
+        """Test the `datetime_array` Data method."""
         d = cfdm.Data([11292.5, 11293], units="days since 1970-1-1")
         dt = d.datetime_array
         self.assertEqual(dt[0], datetime.datetime(2000, 12, 1, 12, 0))
@@ -268,7 +268,7 @@ class DataTest(unittest.TestCase):
         self.assertIs(dt[()], numpy.ma.masked)
 
     def test_Data_flatten(self):
-        """TODO DOCS."""
+        """Test the flatten Data method."""
         ma = numpy.ma.arange(24).reshape(1, 2, 3, 4)
         ma[0, 1, 1, 2] = cfdm.masked
         ma[0, 0, 2, 1] = cfdm.masked
@@ -320,7 +320,7 @@ class DataTest(unittest.TestCase):
             d.flatten(0)
 
     def test_Data_transpose(self):
-        """TODO DOCS."""
+        """Test the transpose Data method."""
         a = numpy.arange(2 * 3 * 5).reshape(2, 1, 3, 5)
         d = cfdm.Data(a.copy())
 
@@ -345,7 +345,7 @@ class DataTest(unittest.TestCase):
         self.assertTrue(d.equals(d.transpose()))
 
     def test_Data_unique(self):
-        """TODO DOCS."""
+        """Test the unique Data method."""
         d = cfdm.Data([[4, 2, 1], [1, 2, 3]], units="metre")
         u = d.unique()
         self.assertEqual(u.shape, (4,))
@@ -359,7 +359,7 @@ class DataTest(unittest.TestCase):
         self.assertTrue((u.array == cfdm.Data([1, 2, 4], "metre").array).all())
 
     def test_Data_equals(self):
-        """TODO DOCS."""
+        """Test the equality-testing Data method."""
         a = numpy.ma.arange(10 * 15 * 19).reshape(10, 1, 15, 19)
         a[0, 0, 2, 3] = numpy.ma.masked
 
@@ -371,7 +371,7 @@ class DataTest(unittest.TestCase):
         self.assertTrue(e.equals(d, verbose=3))
 
     def test_Data_maximum_minimum_sum_squeeze(self):
-        """TODO DOCS."""
+        """Test the maximum, minimum, sum and squeeze Data methods."""
         a = numpy.ma.arange(2 * 3 * 5).reshape(2, 1, 3, 5)
         a[0, 0, 0, 0] = numpy.ma.masked
         a[-1, -1, -1, -1] = numpy.ma.masked
@@ -446,7 +446,7 @@ class DataTest(unittest.TestCase):
             d.maximum(axes=0)
 
     def test_Data_dtype_mask(self):
-        """TODO DOCS."""
+        """Test the dtype and mask Data methods."""
         a = numpy.ma.array(
             [[280.0, -99, -99, -99], [281.0, 279.0, 278.0, 279.0]],
             dtype=float,
@@ -482,22 +482,22 @@ class DataTest(unittest.TestCase):
         self.assertTrue((d.mask.array == numpy.ma.getmaskarray(a)).all())
 
     def test_Data_get_index(self):
-        """TODO DOCS."""
+        """Test the `get_index` Data method."""
         d = cfdm.Data([[281, 279, 278, 279]])
         self.assertIsNone(d.get_index(default=None))
 
     def test_Data_get_list(self):
-        """TODO DOCS."""
+        """Test the `get_list` Data method."""
         d = cfdm.Data([[281, 279, 278, 279]])
         self.assertIsNone(d.get_list(default=None))
 
     def test_Data_get_count(self):
-        """TODO DOCS."""
+        """Test the `get_count` Data method."""
         d = cfdm.Data([[281, 279, 278, 279]])
         self.assertIsNone(d.get_count(default=None))
 
     def test_Data_filled(self):
-        """TODO DOCS."""
+        """Test the filled Data method."""
         d = cfdm.Data([[1, 2, 3]])
         self.assertTrue((d.filled().array == [[1, 2, 3]]).all())
 
@@ -546,7 +546,7 @@ class DataTest(unittest.TestCase):
         self.assertTrue((d.filled().array == ["", "b", "c"]).all())
 
     def test_Data_insert_dimension(self):
-        """TODO DOCS."""
+        """Test the `insert_dimension` Data method."""
         d = cfdm.Data([list(range(12))])
         self.assertEqual(d.shape, (1, 12))
         e = d.squeeze()
@@ -597,7 +597,7 @@ class DataTest(unittest.TestCase):
             d.insert_dimension(1000)
 
     def test_Data_get_compressed_dimension(self):
-        """TODO DOCS."""
+        """Test the `get_compressed_dimension` Data method."""
         d = cfdm.Data([[281, 279, 278, 279]])
         self.assertIsNone(d.get_compressed_dimension(None))
 

--- a/cfdm/test/test_Data.py
+++ b/cfdm/test/test_Data.py
@@ -26,7 +26,7 @@ class DataTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or calls (those

--- a/cfdm/test/test_Data.py
+++ b/cfdm/test/test_Data.py
@@ -23,7 +23,7 @@ def axes_combinations(ndim):
 
 
 class DataTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the Data class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_DimensionCoordinate.py
+++ b/cfdm/test/test_DimensionCoordinate.py
@@ -12,7 +12,7 @@ import cfdm
 
 
 class DimensionCoordinateTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the DimensionCoordinate class."""
 
     filename = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "test_file.nc"

--- a/cfdm/test/test_DimensionCoordinate.py
+++ b/cfdm/test/test_DimensionCoordinate.py
@@ -46,7 +46,7 @@ class DimensionCoordinateTest(unittest.TestCase):
     dim.set_bounds(bounds)
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_DimensionCoordinate.py
+++ b/cfdm/test/test_DimensionCoordinate.py
@@ -59,7 +59,7 @@ class DimensionCoordinateTest(unittest.TestCase):
         # cfdm.log_level('DISABLE')
 
     def test_DimensionCoordinate__repr__str__dump(self):
-        """TODO DOCS."""
+        """Test all means of DimensionCoordinate inspection."""
         f = cfdm.read(self.filename)[0]
         x = f.dimension_coordinates("grid_latitude").value()
 

--- a/cfdm/test/test_DimensionCoordinate.py
+++ b/cfdm/test/test_DimensionCoordinate.py
@@ -69,11 +69,11 @@ class DimensionCoordinateTest(unittest.TestCase):
         self.assertIsInstance(x.dump(display=False, _key="qwerty"), str)
 
     def test_DimensionCoordinate__init__(self):
-        """TODO DOCS."""
+        """Test the constructor of DimensionCoordinate."""
         cfdm.DimensionCoordinate(source="qwerty")
 
     def test_DimensionCoordinate_set_data(self):
-        """TODO DOCS."""
+        """Test the `set_data` DimensionCoordinate method."""
         x = cfdm.DimensionCoordinate()
 
         y = x.set_data(cfdm.Data([1, 2, 3]))
@@ -95,7 +95,7 @@ class DimensionCoordinateTest(unittest.TestCase):
             y = x.set_data(cfdm.Data(1))
 
     def test_DimensionCoordinate_climatology(self):
-        """TODO DOCS."""
+        """Test the climatology DimensionCoordinate methods."""
         x = cfdm.DimensionCoordinate()
 
         self.assertFalse(x.is_climatology())

--- a/cfdm/test/test_Domain.py
+++ b/cfdm/test/test_Domain.py
@@ -13,7 +13,7 @@ class DomainTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.LOG_LEVEL("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_Domain.py
+++ b/cfdm/test/test_Domain.py
@@ -33,7 +33,7 @@ class DomainTest(unittest.TestCase):
         self.f = f[0]
 
     def test_Domain__repr__str__dump(self):
-        """TODO DOCS."""
+        """Test all means of Domain inspection."""
         d = self.f.domain
 
         _ = repr(d)

--- a/cfdm/test/test_Domain.py
+++ b/cfdm/test/test_Domain.py
@@ -10,7 +10,7 @@ import cfdm
 
 
 class DomainTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the Domain class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -41,7 +41,7 @@ class DomainTest(unittest.TestCase):
         self.assertIsInstance(d.dump(display=False), str)
 
     def test_Domain_equals(self):
-        """TODO DOCS."""
+        """Test the equality-testing Domain method."""
         f = self.f
 
         d = f.domain

--- a/cfdm/test/test_DomainAncillary.py
+++ b/cfdm/test/test_DomainAncillary.py
@@ -50,7 +50,7 @@ class DomainAncillaryTest(unittest.TestCase):
         self.assertIsInstance(x.dump(display=False), str)
 
     def test_DomainAncillary_bounds(self):
-        """TODO DOCS."""
+        """Test the bounds keyword argument to DomainAncillary."""
         f = cfdm.read(self.filename)[0]
 
         a = f.auxiliary_coordinates("latitude").value()

--- a/cfdm/test/test_DomainAncillary.py
+++ b/cfdm/test/test_DomainAncillary.py
@@ -32,7 +32,7 @@ class DomainAncillaryTest(unittest.TestCase):
         )
 
     def test_DomainAncillary__repr__str__dump(self):
-        """TODO DOCS."""
+        """Test all means of DomainAncillary inspection."""
         f = cfdm.read(self.filename)[0]
         domain_ancillaries = f.domain_ancillaries("ncvar%a")
 

--- a/cfdm/test/test_DomainAncillary.py
+++ b/cfdm/test/test_DomainAncillary.py
@@ -15,7 +15,7 @@ class DomainAncillaryTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_DomainAncillary.py
+++ b/cfdm/test/test_DomainAncillary.py
@@ -57,7 +57,7 @@ class DomainAncillaryTest(unittest.TestCase):
         cfdm.DomainAncillary(bounds=a)
 
     def test_DomainAncillary_properties(self):
-        """TODO DOCS."""
+        """Test the property access methods of DomainAncillary."""
         f = cfdm.read(self.filename)[0]
         x = f.domain_ancillaries("ncvar%a").value()
 
@@ -69,7 +69,7 @@ class DomainAncillaryTest(unittest.TestCase):
         self.assertIsNone(x.del_property("long_name", None))
 
     def test_DomainAncillary_insert_dimension(self):
-        """TODO DOCS."""
+        """Test the `insert_dimension` DomainAncillary method."""
         f = cfdm.read(self.filename)[0]
         d = f.dimension_coordinates("grid_longitude").value()
         x = cfdm.DomainAncillary(source=d)
@@ -86,7 +86,7 @@ class DomainAncillaryTest(unittest.TestCase):
         self.assertEqual(x.bounds.shape, (9, 1, 2), x.bounds.shape)
 
     def test_DomainAncillary_transpose(self):
-        """TODO DOCS."""
+        """Test the transpose DomainAncillary method."""
         f = cfdm.read(self.filename)[0]
         a = f.auxiliary_coordinates("longitude").value()
         bounds = cfdm.Bounds(
@@ -107,7 +107,7 @@ class DomainAncillaryTest(unittest.TestCase):
         self.assertEqual(x.bounds.shape, (10, 9, 4), x.bounds.shape)
 
     def test_DomainAncillary_squeeze(self):
-        """TODO DOCS."""
+        """Test the squeeze DomainAncillary method."""
         f = cfdm.read(self.filename)[0]
         a = f.auxiliary_coordinates("longitude").value()
         bounds = cfdm.Bounds(

--- a/cfdm/test/test_DomainAncillary.py
+++ b/cfdm/test/test_DomainAncillary.py
@@ -12,7 +12,7 @@ import cfdm
 
 
 class DomainAncillaryTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the DomainAncillary class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_DomainAncillary.py
+++ b/cfdm/test/test_DomainAncillary.py
@@ -54,7 +54,7 @@ class DomainAncillaryTest(unittest.TestCase):
         f = cfdm.read(self.filename)[0]
 
         a = f.auxiliary_coordinates("latitude").value()
-        cfdm.DomainAncillary(source=a)
+        cfdm.DomainAncillary(bounds=a)
 
     def test_DomainAncillary_properties(self):
         """TODO DOCS."""

--- a/cfdm/test/test_DomainAxis.py
+++ b/cfdm/test/test_DomainAxis.py
@@ -36,7 +36,7 @@ class DomainTest(unittest.TestCase):
         self.assertEqual(d.construct_type, "domain_axis")
 
     def test_DomainAxis_source(self):
-        """TODO DOCS."""
+        """Test the source keyword argument to Domain."""
         d = self.d
 
         self.assertTrue(d.equals(cfdm.DomainAxis(source=d)))

--- a/cfdm/test/test_DomainAxis.py
+++ b/cfdm/test/test_DomainAxis.py
@@ -15,7 +15,7 @@ class DomainTest(unittest.TestCase):
     d.nc_set_dimension("ncdim")
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_DomainAxis.py
+++ b/cfdm/test/test_DomainAxis.py
@@ -9,7 +9,7 @@ import cfdm
 
 
 class DomainTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the Domain class."""
 
     d = cfdm.DomainAxis(size=99)
     d.nc_set_dimension("ncdim")

--- a/cfdm/test/test_DomainAxis.py
+++ b/cfdm/test/test_DomainAxis.py
@@ -9,7 +9,7 @@ import cfdm
 
 
 class DomainTest(unittest.TestCase):
-    """Unit test for the Domain class."""
+    """Unit test for the DomainAxis class."""
 
     d = cfdm.DomainAxis(size=99)
     d.nc_set_dimension("ncdim")
@@ -28,7 +28,7 @@ class DomainTest(unittest.TestCase):
         # cfdm.log_level('DISABLE')
 
     def test_DomainAxis__repr__str_construct_type(self):
-        """TODO DOCS."""
+        """Test DomainAxis inspection and `construct_type` method."""
         d = self.d
 
         repr(d)
@@ -36,7 +36,7 @@ class DomainTest(unittest.TestCase):
         self.assertEqual(d.construct_type, "domain_axis")
 
     def test_DomainAxis_source(self):
-        """Test the source keyword argument to Domain."""
+        """Test the source keyword argument to DomainAxis."""
         d = self.d
 
         self.assertTrue(d.equals(cfdm.DomainAxis(source=d)))
@@ -46,7 +46,7 @@ class DomainTest(unittest.TestCase):
         )
 
     def test_DomainAxis_equals(self):
-        """TODO DOCS."""
+        """Test the equality-testing DomainAxis method."""
         d = self.d
         e = d.copy()
 
@@ -55,7 +55,7 @@ class DomainTest(unittest.TestCase):
         self.assertTrue(e.equals(d, verbose=3))
 
     def test_DomainAxis_size(self):
-        """TODO DOCS."""
+        """Test the size access and (un)setting DomainAxis method."""
         d = self.d.copy()
         d.set_size(100)
 
@@ -67,7 +67,7 @@ class DomainTest(unittest.TestCase):
         self.assertFalse(d.has_size())
 
     def test_DomainAxis_unlimited(self):
-        """TODO DOCS."""
+        """Test the netCDF unlimited DomainAxis methods."""
         d = cfdm.DomainAxis()
         d.set_size(99)
 

--- a/cfdm/test/test_DomainAxis.py
+++ b/cfdm/test/test_DomainAxis.py
@@ -8,7 +8,7 @@ faulthandler.enable()  # to debug seg faults and timeouts
 import cfdm
 
 
-class DomainTest(unittest.TestCase):
+class DomainAxisTest(unittest.TestCase):
     """Unit test for the DomainAxis class."""
 
     d = cfdm.DomainAxis(size=99)

--- a/cfdm/test/test_Field.py
+++ b/cfdm/test/test_Field.py
@@ -42,7 +42,7 @@ class FieldTest(unittest.TestCase):
     f1 = cfdm.example_field(1)
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_Field.py
+++ b/cfdm/test/test_Field.py
@@ -55,7 +55,7 @@ class FieldTest(unittest.TestCase):
         # cfdm.log_level('DISABLE')
 
     def test_Field__repr__str__dump_construct_type(self):
-        """TODO DOCS."""
+        """Test all means of Field inspection."""
         f = self.f1
 
         repr(f)

--- a/cfdm/test/test_Field.py
+++ b/cfdm/test/test_Field.py
@@ -64,11 +64,11 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(f.construct_type, "field")
 
     def test_Field__init__(self):
-        """TODO DOCS."""
+        """Test the Field constructor and source keyword."""
         cfdm.Field(source="qwerty")
 
     def test_Field___getitem__(self):
-        """TODO DOCS."""
+        """Test the access of field subspsaces from Field."""
         f = self.f1
         f = f.squeeze()
 
@@ -171,7 +171,7 @@ class FieldTest(unittest.TestCase):
     #            self.assertEqual(counts[0], array.size)
 
     def test_Field_get_filenames(self):
-        """TODO DOCS."""
+        """Test the `get_filenames` Field method."""
         cfdm.write(self.f0, tmpfile)
         g = cfdm.read(tmpfile)[0]
 
@@ -195,7 +195,7 @@ class FieldTest(unittest.TestCase):
         os.remove(tmpfile)
 
     def test_Field_apply_masking(self):
-        """TODO DOCS."""
+        """Test the `apply_masking` Field method."""
         f = self.f0.copy()
 
         for prop in (
@@ -248,7 +248,7 @@ class FieldTest(unittest.TestCase):
         self.assertTrue(e.equals(g.data, verbose=3))
 
     def test_Field_PROPERTIES(self):
-        """TODO DOCS."""
+        """Test the property access methods of Field."""
         f = self.f1.copy()
         for name, value in f.properties().items():
             self.assertTrue(f.has_property(name))
@@ -266,7 +266,7 @@ class FieldTest(unittest.TestCase):
         f.set_properties(d, copy=False)
 
     def test_Field_set_get_del_has_data(self):
-        """TODO DOCS."""
+        """Test the data access and (un)setting methods of Field."""
         f = self.f1.copy()
 
         self.assertTrue(f.has_data())
@@ -303,7 +303,7 @@ class FieldTest(unittest.TestCase):
         self.assertTrue(g.data.equals(d))
 
     def test_Field_construct_item(self):
-        """TODO DOCS."""
+        """Test the `construct_item` Field method."""
         f = self.f1
 
         out = f.construct_item("key%domainaxis0")
@@ -312,7 +312,7 @@ class FieldTest(unittest.TestCase):
         self.assertIsInstance(out[1], cfdm.DomainAxis)
 
     def test_Field_CONSTRUCTS(self):
-        """TODO DOCS."""
+        """Test the construct access Field methods."""
         f = self.f1
 
         f.construct("latitude")
@@ -379,7 +379,7 @@ class FieldTest(unittest.TestCase):
         )
 
     def test_Field_domain_axes(self):
-        """TODO DOCS."""
+        """Test the `domain_axes` Field method."""
         f = self.f1
 
         regex = re.compile("^atmos")
@@ -390,7 +390,7 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(len(f.domain_axes(regex, "grid_latitude", -1)), 3)
 
     def test_Field_data_axes(self):
-        """TODO DOCS."""
+        """Test the data axes access and (un)setting Field methods."""
         f = self.f1.copy()
 
         ref = f.get_data_axes()
@@ -404,7 +404,7 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(f.get_data_axes(), ref)
 
     def test_Field_convert(self):
-        """TODO DOCS."""
+        """Test the convert Field method."""
         f = self.f1
 
         key = f.construct_key("grid_latitude")
@@ -443,7 +443,7 @@ class FieldTest(unittest.TestCase):
             f.convert("domainaxis0")
 
     def test_Field_equals(self):
-        """TODO DOCS."""
+        """Test the equality-testing Field method."""
         f = self.f1
 
         self.assertTrue(f.equals(f, verbose=3))
@@ -474,7 +474,7 @@ class FieldTest(unittest.TestCase):
         self.assertFalse(g.equals(f))
 
     def test_Field_del_construct(self):
-        """TODO DOCS."""
+        """Test the `del_construct` Field method."""
         f = self.f1.copy()
 
         self.assertIsInstance(
@@ -493,7 +493,7 @@ class FieldTest(unittest.TestCase):
         )
 
     def test_Field_has_construct(self):
-        """TODO DOCS."""
+        """Test the `has_construct` Field method."""
         f = self.f1.copy()
 
         self.assertTrue(f.has_construct("latitude"))
@@ -507,7 +507,7 @@ class FieldTest(unittest.TestCase):
         self.assertTrue(f.has_construct(""))
 
     def test_Field_squeeze_transpose_insert_dimension(self):
-        """TODO DOCS."""
+        """Test squeeze, transpose and `insert_dimension` methods."""
         f = self.f1
 
         g = f.transpose()
@@ -535,7 +535,7 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(h.get_data_axes()[:-1], f.get_data_axes())
 
     def test_Field_compress_uncompress(self):
-        """TODO DOCS."""
+        """Test the compress and uncompress Field methods."""
         contiguous = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
             "DSG_timeSeries_contiguous.nc",
@@ -595,7 +595,7 @@ class FieldTest(unittest.TestCase):
                     self.assertTrue(f.equals(c, verbose=3), message)
 
     def test_Field_creation_commands(self):
-        """TODO DOCS."""
+        """Test the `creation_commands` Field method."""
         for i in range(7):
             f = cfdm.example_field(i)
 
@@ -614,7 +614,7 @@ class FieldTest(unittest.TestCase):
             f.creation_commands(namespace=ns)
 
     def test_Field_has_geometry(self):
-        """TODO DOCS."""
+        """Test the `creation_commands` Field method."""
         f = self.f1
         self.assertFalse(f.has_geometry())
 

--- a/cfdm/test/test_Field.py
+++ b/cfdm/test/test_Field.py
@@ -36,7 +36,7 @@ atexit.register(_remove_tmpfiles)
 
 
 class FieldTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the Field class."""
 
     f0 = cfdm.example_field(0)
     f1 = cfdm.example_field(1)

--- a/cfdm/test/test_FieldAncillary.py
+++ b/cfdm/test/test_FieldAncillary.py
@@ -42,7 +42,7 @@ class FieldAncillaryTest(unittest.TestCase):
         self.assertIsInstance(x.dump(display=False), str)
 
     def test_FieldAncillary_source(self):
-        """TODO DOCS."""
+        """Test the source keyword argument to FieldAncillary."""
         f = self.f.copy()
 
         a = f.auxiliary_coordinates("latitude").value()

--- a/cfdm/test/test_FieldAncillary.py
+++ b/cfdm/test/test_FieldAncillary.py
@@ -10,7 +10,7 @@ import cfdm
 
 
 class FieldAncillaryTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the FieldAncillary class."""
 
     filename = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "test_file.nc"

--- a/cfdm/test/test_FieldAncillary.py
+++ b/cfdm/test/test_FieldAncillary.py
@@ -33,7 +33,7 @@ class FieldAncillaryTest(unittest.TestCase):
         self.f = cfdm.read(self.filename)[0]
 
     def test_FieldAncillary__repr__str__dump(self):
-        """TODO DOCS."""
+        """Test all means of FieldAncillary inspection."""
         f = self.f.copy()
         x = f.field_ancillaries("ancillaryA").value()
 

--- a/cfdm/test/test_FieldAncillary.py
+++ b/cfdm/test/test_FieldAncillary.py
@@ -19,7 +19,7 @@ class FieldAncillaryTest(unittest.TestCase):
     #    f = cfdm.read(filename)[0]
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_FieldAncillary.py
+++ b/cfdm/test/test_FieldAncillary.py
@@ -49,7 +49,7 @@ class FieldAncillaryTest(unittest.TestCase):
         cfdm.FieldAncillary(source=a)
 
     def test_FieldAncillary_properties(self):
-        """TODO DOCS."""
+        """Test the property access methods of FieldAncillary."""
         f = self.f.copy()
         x = f.domain_ancillaries("ncvar%a").value()
         x = cfdm.FieldAncillary(source=x)
@@ -62,7 +62,7 @@ class FieldAncillaryTest(unittest.TestCase):
         self.assertIsNone(x.del_property("long_name", None))
 
     def test_FieldAncillary_insert_dimension(self):
-        """TODO DOCS."""
+        """Test the `insert_dimension` FieldAncillary method."""
         f = self.f.copy()
         d = f.dimension_coordinates("grid_longitude").value()
         x = cfdm.FieldAncillary(source=d)
@@ -76,7 +76,7 @@ class FieldAncillaryTest(unittest.TestCase):
         self.assertEqual(x.shape, (9, 1))
 
     def test_FieldAncillary_transpose(self):
-        """TODO DOCS."""
+        """Test the transpose FieldAncillary method."""
         f = self.f.copy()
         a = f.auxiliary_coordinates("longitude").value()
         x = cfdm.FieldAncillary(source=a)
@@ -90,7 +90,7 @@ class FieldAncillaryTest(unittest.TestCase):
         self.assertEqual(x.shape, (10, 9))
 
     def test_FieldAncillary_squeeze(self):
-        """TODO DOCS."""
+        """Test the squeeze FieldAncillary method."""
         f = self.f.copy()
         a = f.auxiliary_coordinates("longitude").value()
         x = cfdm.FieldAncillary(source=a)

--- a/cfdm/test/test_Index.py
+++ b/cfdm/test/test_Index.py
@@ -9,7 +9,7 @@ import cfdm
 
 
 class IndexTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the Index class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_Index.py
+++ b/cfdm/test/test_Index.py
@@ -27,7 +27,7 @@ class IndexTest(unittest.TestCase):
         self.indexed = "DSG_timeSeries_indexed.nc"
 
     def test_Index__repr__str__dump(self):
-        """TODO DOCS."""
+        """Test all means of Index inspection."""
         f = cfdm.read(self.indexed)[0]
 
         index = f.data.get_index()

--- a/cfdm/test/test_Index.py
+++ b/cfdm/test/test_Index.py
@@ -12,7 +12,7 @@ class IndexTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_InteriorRing.py
+++ b/cfdm/test/test_InteriorRing.py
@@ -13,7 +13,7 @@ class InteriorRingTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.LOG_LEVEL("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_InteriorRing.py
+++ b/cfdm/test/test_InteriorRing.py
@@ -10,7 +10,7 @@ import cfdm
 
 
 class InteriorRingTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the InteriorRing class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_InteriorRing.py
+++ b/cfdm/test/test_InteriorRing.py
@@ -34,7 +34,7 @@ class InteriorRingTest(unittest.TestCase):
         )
 
     def test_InteriorRing__repr__str__dump(self):
-        """TODO DOCS."""
+        """Test all means of InteriorRing inspection."""
         f = cfdm.read(self.geometry_interior_ring_file)[0]
 
         coord = f.construct("axis=X")

--- a/cfdm/test/test_List.py
+++ b/cfdm/test/test_List.py
@@ -9,7 +9,7 @@ import cfdm
 
 
 class ListTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the List class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_List.py
+++ b/cfdm/test/test_List.py
@@ -27,7 +27,7 @@ class ListTest(unittest.TestCase):
         self.gathered = "gathered.nc"
 
     def test_List__repr__str__dump(self):
-        """TODO DOCS."""
+        """Test all means of List inspection."""
         f = cfdm.read(self.gathered)[0]
 
         list_ = f.data.get_list()

--- a/cfdm/test/test_List.py
+++ b/cfdm/test/test_List.py
@@ -12,7 +12,7 @@ class ListTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_NodeCountProperties.py
+++ b/cfdm/test/test_NodeCountProperties.py
@@ -34,7 +34,7 @@ class NodeCountPropertiesTest(unittest.TestCase):
         )
 
     def test_NodeCountProperties__repr__str__dump(self):
-        """TODO DOCS."""
+        """Test all means of NodeCountProperties inspection."""
         f = cfdm.read(self.geometry_interior_ring_file)[0]
 
         coord = f.construct("axis=X")

--- a/cfdm/test/test_NodeCountProperties.py
+++ b/cfdm/test/test_NodeCountProperties.py
@@ -10,7 +10,7 @@ import cfdm
 
 
 class NodeCountPropertiesTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the NodeCountProperties class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_NodeCountProperties.py
+++ b/cfdm/test/test_NodeCountProperties.py
@@ -13,7 +13,7 @@ class NodeCountPropertiesTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_NumpyArray.py
+++ b/cfdm/test/test_NumpyArray.py
@@ -26,7 +26,7 @@ class NumpyArrayTest(unittest.TestCase):
         # cfdm.log_level('DISABLE')
 
     def test_NumpyArray_copy(self):
-        """TODO DOCS."""
+        """Test the copy module copying behaviour of NumpyArray."""
         a = numpy.array([1, 2, 3, 4])
 
         x = cfdm.NumpyArray(a)
@@ -35,7 +35,7 @@ class NumpyArrayTest(unittest.TestCase):
         self.assertTrue((x.array == y.array).all())
 
     def test_NumpyArray__array__(self):
-        """TODO DOCS."""
+        """Test the NumPy array conversion of NumpyArray."""
         a = numpy.array([1, 2, 3, 4])
 
         x = cfdm.NumpyArray(a)

--- a/cfdm/test/test_NumpyArray.py
+++ b/cfdm/test/test_NumpyArray.py
@@ -14,7 +14,7 @@ class NumpyArrayTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.LOG_LEVEL("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_NumpyArray.py
+++ b/cfdm/test/test_NumpyArray.py
@@ -11,7 +11,7 @@ import cfdm
 
 
 class NumpyArrayTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the NumpyArray class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_PartNodeCountProperties.py
+++ b/cfdm/test/test_PartNodeCountProperties.py
@@ -13,7 +13,7 @@ class PartNodeCountPropertiesTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_PartNodeCountProperties.py
+++ b/cfdm/test/test_PartNodeCountProperties.py
@@ -10,7 +10,7 @@ import cfdm
 
 
 class PartNodeCountPropertiesTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the PartNodeCountProperties class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_PartNodeCountProperties.py
+++ b/cfdm/test/test_PartNodeCountProperties.py
@@ -34,7 +34,7 @@ class PartNodeCountPropertiesTest(unittest.TestCase):
         )
 
     def test_PartNodeCountProperties__repr__str__dump(self):
-        """TODO DOCS."""
+        """Test all means of PartNodeCountProperties inspection."""
         f = cfdm.read(self.geometry_interior_ring_file)[0]
 
         coord = f.construct("axis=X")

--- a/cfdm/test/test_RaggedContiguousArray.py
+++ b/cfdm/test/test_RaggedContiguousArray.py
@@ -29,11 +29,11 @@ class RaggedContiguousArrayTest(unittest.TestCase):
         )
 
     def test_RaggedContiguousArray_to_memory(self):
-        """TODO DOCS."""
+        """Test the `to_memory` RaggedContiguousArray method."""
         self.assertIsInstance(self.r.to_memory(), cfdm.RaggedContiguousArray)
 
     def test_RaggedContiguousArray_get_count(self):
-        """TODO DOCS."""
+        """Test the `get_count` RaggedContiguousArray method."""
         r = self.r
         self.assertIsInstance(r.get_count(), cfdm.Count)
         r._del_component("count_variable")

--- a/cfdm/test/test_RaggedContiguousArray.py
+++ b/cfdm/test/test_RaggedContiguousArray.py
@@ -12,7 +12,7 @@ class RaggedContiguousArrayTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or calls (those

--- a/cfdm/test/test_RaggedContiguousArray.py
+++ b/cfdm/test/test_RaggedContiguousArray.py
@@ -9,7 +9,7 @@ import cfdm
 
 
 class RaggedContiguousArrayTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the RaggedContiguousArray class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_RaggedIndexedArray.py
+++ b/cfdm/test/test_RaggedIndexedArray.py
@@ -9,7 +9,7 @@ import cfdm
 
 
 class RaggedIndexedArrayTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the RaggedIndexedArray class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_RaggedIndexedArray.py
+++ b/cfdm/test/test_RaggedIndexedArray.py
@@ -12,7 +12,7 @@ class RaggedIndexedArrayTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or calls (those

--- a/cfdm/test/test_RaggedIndexedArray.py
+++ b/cfdm/test/test_RaggedIndexedArray.py
@@ -29,11 +29,11 @@ class RaggedIndexedArrayTest(unittest.TestCase):
         )
 
     def test_RaggedIndexedArray_to_memory(self):
-        """TODO DOCS."""
+        """Test the `to_memory` RaggedIndexedArray method."""
         self.assertIsInstance(self.r.to_memory(), cfdm.RaggedIndexedArray)
 
     def test_RaggedIndexedArray_get_index(self):
-        """TODO DOCS."""
+        """Test the `get_index` RaggedIndexedArray method."""
         r = self.r
         self.assertIsInstance(r.get_index(), cfdm.Index)
         r._del_component("index_variable")

--- a/cfdm/test/test_RaggedIndexedContiguousArray.py
+++ b/cfdm/test/test_RaggedIndexedContiguousArray.py
@@ -9,7 +9,7 @@ import cfdm
 
 
 class RaggedIndexedContiguousArrayTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the RaggedIndexedContiguousArray class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_RaggedIndexedContiguousArray.py
+++ b/cfdm/test/test_RaggedIndexedContiguousArray.py
@@ -23,7 +23,7 @@ class RaggedIndexedContiguousArrayTest(unittest.TestCase):
         # cfdm.log_level('DISABLE')
 
     def test_RaggedIndexedContiguousArray_to_memory(self):
-        """TODO DOCS."""
+        """Test the `to_memory` RaggedIndexedContiguousArray method."""
         compressed_data = cfdm.Data(
             [
                 280.0,

--- a/cfdm/test/test_RaggedIndexedContiguousArray.py
+++ b/cfdm/test/test_RaggedIndexedContiguousArray.py
@@ -12,7 +12,7 @@ class RaggedIndexedContiguousArrayTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or calls (those

--- a/cfdm/test/test_core_1.py
+++ b/cfdm/test/test_core_1.py
@@ -13,7 +13,7 @@ verbose = False
 
 
 class create_fieldTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the `cfdm.core` package."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -29,7 +29,7 @@ class create_fieldTest(unittest.TestCase):
         # cfdm.log_level('DISABLE')
 
     def test_core_create_field(self):
-        """TODO DOCS."""
+        """Test ab initio creation of a `cfdm.core` Field."""
         # Dimension coordinates
         dim1 = cfdm.core.DimensionCoordinate(
             data=cfdm.core.Data(cfdm.core.NumpyArray(numpy.arange(10.0)))
@@ -253,7 +253,7 @@ class create_fieldTest(unittest.TestCase):
         f.set_construct(cm1)
 
     def test_core_FUNCTIONS(self):
-        """TODO DOCS."""
+        """Test the functions of the `cfdm.core` functions module."""
         self.assertEqual(cfdm.core.CF(), cfdm.core.__cf_version__)
 
         self.assertIsInstance(cfdm.core.environment(display=False), list)

--- a/cfdm/test/test_core_1.py
+++ b/cfdm/test/test_core_1.py
@@ -16,7 +16,7 @@ class create_fieldTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_decorators.py
+++ b/cfdm/test/test_decorators.py
@@ -47,7 +47,7 @@ class dummyClass:
     """
 
     def __init__(self):
-        """TODO DOCS."""
+        """Constructor for dummyClass."""
         self._list = [1]
 
         self.debug_message = DEBUG_MSG
@@ -58,7 +58,7 @@ class dummyClass:
         self.dummy_string = "foo bar baz"
 
     def copy(self):
-        """TODO DOCS."""
+        """Creates a deep copy."""
         return copy.deepcopy(self)  # note a shallow copy is not sufficient
 
     def func(self, inplace):
@@ -129,11 +129,11 @@ class dummyClass:
         logger.warning(self.warning_message)
 
 
-class DecoratorsTest(unittest.TestCase):
-    """TODO DOCS."""
+class decoratorsTest(unittest.TestCase):
+    """Test the decorators module."""
 
     def test_inplace_enabled(self):
-        """TODO DOCS."""
+        """Test the `_inplace_enabled` decorator."""
         # Note we must initiate separate classes as a list is mutable:
         test_class_1 = dummyClass()
         test_class_2 = dummyClass()
@@ -157,7 +157,7 @@ class DecoratorsTest(unittest.TestCase):
         self.assertEqual(res_4, None)  # as return None if inplace=True
 
     def test_manage_log_level_via_verbosity(self):
-        """TODO DOCS."""
+        """Test the `_manage_log_level_via_verbosity` decorator."""
         # Order of decreasing severity/verbosity is crucial to one test below
         levels = ["WARNING", "INFO", "DETAIL", "DEBUG"]
 
@@ -257,7 +257,7 @@ class DecoratorsTest(unittest.TestCase):
 
     @patch("builtins.print")
     def test_display_or_return(self, mock_print):
-        """TODO DOCS."""
+        """Test the `_display_or_return` decorator."""
         test_class = dummyClass()
 
         # Compare results with display=False:

--- a/cfdm/test/test_docstring.py
+++ b/cfdm/test/test_docstring.py
@@ -39,7 +39,7 @@ def _get_all_abbrev_subclasses(klass):
 
 
 class DocstringTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Test the system for cross-package docstring substitutions."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -77,7 +77,7 @@ class DocstringTest(unittest.TestCase):
         )
 
     def test_class_docstring_rewrite(self):
-        """TODO DOCS."""
+        """Test the DocstringRewriteMeta (meta)class."""
 
         class parent(metaclass=cfdm.core.meta.DocstringRewriteMeta):
             pass
@@ -176,8 +176,7 @@ class DocstringTest(unittest.TestCase):
         self.assertEqual(grandchild.__doc__, "grandchild.")
 
     def test_docstring(self):
-        """TODO DOCS."""
-        # Test that all {{ occurrences have been substituted
+        """Test that all '{{' occurrences have been substituted."""
         for klass in self.subclasses_of_Container:
             for x in (klass, klass()):
                 for name in dir(x):
@@ -207,7 +206,7 @@ class DocstringTest(unittest.TestCase):
                     )
 
     def test_docstring_package(self):
-        """TODO DOCS."""
+        """Test the docstring substitution of the pacakage name."""
         string = ">>> f = {}.".format(self.package)
         for klass in self.subclasses_of_Container:
             for x in (klass, klass()):
@@ -219,7 +218,7 @@ class DocstringTest(unittest.TestCase):
                 self.assertIn(string, x.clear_properties.__doc__, klass)
 
     def test_docstring_class(self):
-        """TODO DOCS."""
+        """Test the docstring substitution of the class name."""
         for klass in self.subclasses_of_Properties:
             string = ">>> f = {}.{}".format(self.package, klass.__name__)
             for x in (klass, klass()):
@@ -252,21 +251,21 @@ class DocstringTest(unittest.TestCase):
                 )
 
     def test_docstring_repr(self):
-        """TODO DOCS."""
+        """Test docstring substitution of the object representation."""
         string = "<{}Data".format(self.repr)
         for klass in self.subclasses_of_PropertiesData:
             for x in (klass, klass()):
                 self.assertIn(string, x.has_data.__doc__, klass)
 
     def test_docstring_default(self):
-        """TODO DOCS."""
-        string = "Return the value of the *default* parameter"
+        """Test a given string gets substituted into a docstring."""
+        string = "Return the value of the *default* parameterY"
         for klass in self.subclasses_of_Properties:
             for x in (klass, klass()):
                 self.assertIn(string, x.del_property.__doc__, klass)
 
     def test_docstring_staticmethod(self):
-        """TODO DOCS."""
+        """Test docstring substitution on a static method."""
         for klass in self.subclasses_of_PropertiesData:
             x = klass
             self.assertEqual(
@@ -274,7 +273,7 @@ class DocstringTest(unittest.TestCase):
             )
 
     def test_docstring_classmethod(self):
-        """TODO DOCS."""
+        """Test docstring substitution on a class method."""
         for klass in self.subclasses_of_PropertiesData:
             for x in (klass, klass()):
                 self.assertEqual(
@@ -282,7 +281,7 @@ class DocstringTest(unittest.TestCase):
                 )
 
     def test_docstring_docstring_substitutions(self):
-        """TODO DOCS."""
+        """Test the `_docstring substitution` internal method."""
         for klass in self.subclasses_of_Container:
             for x in (klass,):
                 d = x._docstring_substitutions(klass)

--- a/cfdm/test/test_docstring.py
+++ b/cfdm/test/test_docstring.py
@@ -176,7 +176,7 @@ class DocstringTest(unittest.TestCase):
         self.assertEqual(grandchild.__doc__, "grandchild.")
 
     def test_docstring(self):
-        """Test that all '{{' occurrences have been substituted."""
+        """Test that all double-brace markers have been substituted."""
         for klass in self.subclasses_of_Container:
             for x in (klass, klass()):
                 for name in dir(x):
@@ -259,7 +259,7 @@ class DocstringTest(unittest.TestCase):
 
     def test_docstring_default(self):
         """Test a given string gets substituted into a docstring."""
-        string = "Return the value of the *default* parameterY"
+        string = "Return the value of the *default* parameter"
         for klass in self.subclasses_of_Properties:
             for x in (klass, klass()):
                 self.assertIn(string, x.del_property.__doc__, klass)

--- a/cfdm/test/test_docstring.py
+++ b/cfdm/test/test_docstring.py
@@ -42,7 +42,7 @@ class DocstringTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         self.package = "cfdm"
         self.repr = ""
 

--- a/cfdm/test/test_dsg.py
+++ b/cfdm/test/test_dsg.py
@@ -160,7 +160,7 @@ class DSGTest(unittest.TestCase):
     b = numpy.ma.where(b == -99, numpy.ma.masked, b)
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_dsg.py
+++ b/cfdm/test/test_dsg.py
@@ -34,7 +34,7 @@ atexit.register(_remove_tmpfiles)
 
 
 class DSGTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Test discrete sampling geometry features."""
 
     contiguous = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
@@ -271,7 +271,7 @@ class DSGTest(unittest.TestCase):
     #        self.b = b
 
     def test_DSG_contiguous(self):
-        """TODO DOCS."""
+        """Test the contiguous ragged array DSG representation."""
         f = self.c.copy()
 
         self.assertEqual(len(f), 2)
@@ -340,7 +340,7 @@ class DSGTest(unittest.TestCase):
         cfdm.write(tas, tempfile)
 
     def test_DSG_indexed(self):
-        """TODO DOCS."""
+        """Test the indexed ragged array DSG representation."""
         f = self.i.copy()
 
         self.assertEqual(len(f), 2)
@@ -363,7 +363,7 @@ class DSGTest(unittest.TestCase):
             self.assertTrue(g[i].equals(f[i], verbose=3))
 
     def test_DSG_indexed_contiguous(self):
-        """TODO DOCS."""
+        """Test the indexed contiguous ragged array representation."""
         f = self.ic.copy()
 
         self.assertEqual(len(f), 2)
@@ -395,7 +395,7 @@ class DSGTest(unittest.TestCase):
             self.assertTrue(g[i].equals(f[i], verbose=3))
 
     def test_DSG_create_contiguous(self):
-        """TODO DOCS."""
+        """Test the creation of a contiguous ragged array."""
         # Define the ragged array values
         ragged_array = numpy.array([1, 3, 4, 3, 6], dtype="float32")
         # Define the count array values

--- a/cfdm/test/test_dsg.py
+++ b/cfdm/test/test_dsg.py
@@ -34,7 +34,7 @@ atexit.register(_remove_tmpfiles)
 
 
 class DSGTest(unittest.TestCase):
-    """Test discrete sampling geometry features."""
+    """Test discrete sampling geometry ragged array representations."""
 
     contiguous = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),

--- a/cfdm/test/test_external.py
+++ b/cfdm/test/test_external.py
@@ -36,7 +36,7 @@ atexit.register(_remove_tmpfiles)
 
 
 class ExternalVariableTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Test handling of variables stored in external netCDF files."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -60,7 +60,7 @@ class ExternalVariableTest(unittest.TestCase):
         )
 
     def test_EXTERNAL_READ(self):
-        """TODO DOCS."""
+        """Test read function reading of external netCDF variables."""
         # Read the parent file on its own, without the external file
         f = cfdm.read(self.parent_file)
 
@@ -136,7 +136,7 @@ class ExternalVariableTest(unittest.TestCase):
             self.assertTrue(c[i].equals(f[i], verbose=3))
 
     def test_EXTERNAL_WRITE(self):
-        """TODO DOCS."""
+        """Test write function writing of external netCDF variables."""
         parent = cfdm.read(self.parent_file)
         combined = cfdm.read(self.combined_file)
 

--- a/cfdm/test/test_external.py
+++ b/cfdm/test/test_external.py
@@ -39,7 +39,7 @@ class ExternalVariableTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.LOG_LEVEL("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_functions.py
+++ b/cfdm/test/test_functions.py
@@ -58,7 +58,7 @@ class FunctionsTest(unittest.TestCase):
         # (no tearDownClass necessary)
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warning, but
         # save original state for test on logging (see test_log_level)
         cfdm.log_level("DISABLE")

--- a/cfdm/test/test_functions.py
+++ b/cfdm/test/test_functions.py
@@ -38,11 +38,11 @@ atexit.register(_remove_tmpfiles)
 
 
 class FunctionsTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Test the functions of the non-core functions module."""
 
     @classmethod
     def setUpClass(cls):
-        """TODO DOCS."""
+        """Preparations called before the test class runs."""
         # Need to run this per-class, not per-method, to access the
         # original value of log_level to use to test the default (see
         # test_log_level)
@@ -89,7 +89,7 @@ class FunctionsTest(unittest.TestCase):
         ]
 
     def test_atol_rtol(self):
-        """TODO DOCS."""
+        """Test the atol and rtol functions."""
         org = cfdm.RTOL()
         self.assertEqual(cfdm.RTOL(1e-5), org)
         self.assertEqual(cfdm.RTOL(), 1e-5)
@@ -111,7 +111,7 @@ class FunctionsTest(unittest.TestCase):
         self.assertTrue(cfdm.atol() == org)
 
     def test_log_level(self):
-        """TODO DOCS."""
+        """Test the `log_level` function."""
         original = self.__class__.original  # original to module i.e. default
 
         self.assertEqual(original, "WARNING")  # test default
@@ -142,7 +142,7 @@ class FunctionsTest(unittest.TestCase):
             cfdm.LOG_LEVEL("ERROR")
 
     def test_reset_log_emergence_level(self):
-        """TODO DOCS."""
+        """Test the `_reset_log_emergence_level` internal function."""
         # 'DISABLE' is special case so test it afterwards (see below)
         for value in self.valid_level_values:
             cfdm.functions._reset_log_emergence_level(value)
@@ -170,7 +170,7 @@ class FunctionsTest(unittest.TestCase):
         )
 
     def test_disable_logging(self):
-        """TODO DOCS."""
+        """Test the `_disable_logging` internal function."""
         # Re-set to avoid coupling; use set level to check it is
         # restored after
         cfdm.log_level("DETAIL")
@@ -200,11 +200,11 @@ class FunctionsTest(unittest.TestCase):
         self.assertFalse(cfdm.logging.getLogger().isEnabledFor(logging.DEBUG))
 
     def test_CF(self):
-        """TODO DOCS."""
+        """Test the CF function."""
         self.assertEqual(cfdm.CF(), cfdm.core.__cf_version__)
 
     def test_environment(self):
-        """TODO DOCS."""
+        """Test the `environment` function."""
         e = cfdm.environment(display=False)
         ep = cfdm.environment(display=False, paths=False)
 
@@ -230,7 +230,7 @@ class FunctionsTest(unittest.TestCase):
             self.assertIn(component, ep)
 
     def test_example_field(self):
-        """TODO DOCS."""
+        """Test the `example_field` function."""
         top = 7
 
         for n in range(top + 1):
@@ -253,7 +253,7 @@ class FunctionsTest(unittest.TestCase):
             cfdm.example_field(1, 2)
 
     def test_abspath(self):
-        """TODO DOCS."""
+        """Test the abspath function."""
         filename = "test_file.nc"
         self.assertEqual(cfdm.abspath(filename), os.path.abspath(filename))
         filename = "http://test_file.nc"
@@ -262,7 +262,7 @@ class FunctionsTest(unittest.TestCase):
         self.assertEqual(cfdm.abspath(filename), filename)
 
     def test_configuration(self):
-        """TODO DOCS."""
+        """Test the configuration function."""
         # Test getting of all config. and store original values to test on:
         org = cfdm.configuration()
         self.assertIsInstance(org, dict)
@@ -365,7 +365,7 @@ class FunctionsTest(unittest.TestCase):
             )
 
     def test_context_managers(self):
-        """TODO DOCS."""
+        """Test the context manager support of the functions."""
         # rtol and atol
         for func in (
             cfdm.atol,
@@ -419,7 +419,7 @@ class FunctionsTest(unittest.TestCase):
         func(**org)
 
     def test_Constant(self):
-        """TODO DOCS."""
+        """Test the Constant class."""
         c = cfdm.Constant(20)
         d = cfdm.Constant(10)
         e = cfdm.Constant(999)
@@ -507,7 +507,7 @@ class FunctionsTest(unittest.TestCase):
         self.assertFalse(cfdm.Constant(False))
 
     def test_Configuration(self):
-        """TODO DOCS."""
+        """Test the Configuration class."""
         c = cfdm.configuration()
 
         self.assertIsInstance(repr(c), str)

--- a/cfdm/test/test_gathering.py
+++ b/cfdm/test/test_gathering.py
@@ -34,7 +34,7 @@ atexit.register(_remove_tmpfiles)
 
 
 class GatheredTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Test management of constructs with underlying gathered arrays."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -256,7 +256,7 @@ class GatheredTest(unittest.TestCase):
         self.b = b
 
     def test_GATHERING(self):
-        """TODO DOCS."""
+        """Test reading and writing of a field with a gathered array."""
         f = cfdm.read(self.gathered, verbose=False)
 
         self.assertEqual(len(f), 3)
@@ -273,7 +273,7 @@ class GatheredTest(unittest.TestCase):
             self.assertTrue(g[i].equals(f[i], verbose=3))
 
     def test_GATHERING_create(self):
-        """TODO DOCS."""
+        """Test the creation of a construct with a gathered array."""
         # Define the gathered values
         gathered_array = numpy.array(
             [[280, 282.5, 281], [279, 278, 277.5]], dtype="float32"

--- a/cfdm/test/test_gathering.py
+++ b/cfdm/test/test_gathering.py
@@ -37,7 +37,7 @@ class GatheredTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_geometry.py
+++ b/cfdm/test/test_geometry.py
@@ -38,7 +38,7 @@ class DSGTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_geometry.py
+++ b/cfdm/test/test_geometry.py
@@ -35,7 +35,7 @@ VN = cfdm.CF()
 
 
 class DSGTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Test the management of geometry cells."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -72,7 +72,7 @@ class DSGTest(unittest.TestCase):
         )
 
     def test_node_count(self):
-        """TODO DOCS."""
+        """Test geometry coordinate node count variables."""
         f = cfdm.read(self.geometry_1_file, verbose=False)
 
         self.assertEqual(len(f), 2, "f = " + repr(f))
@@ -117,7 +117,7 @@ class DSGTest(unittest.TestCase):
         self.assertFalse(c.has_node_count())
 
     def test_geometry_2(self):
-        """TODO DOCS."""
+        """Test nodes not tied to auxiliary coordinate variables."""
         f = cfdm.read(self.geometry_2_file, verbose=False)
 
         self.assertEqual(len(f), 2, "f = " + repr(f))
@@ -152,7 +152,7 @@ class DSGTest(unittest.TestCase):
         cfdm.write(f, tempfile, verbose=False)
 
     def test_geometry_3(self):
-        """TODO DOCS."""
+        """Test nodes in a file with no node count variable."""
         f = cfdm.read(self.geometry_3_file, verbose=False)
 
         self.assertEqual(len(f), 2, "f = " + repr(f))
@@ -178,7 +178,7 @@ class DSGTest(unittest.TestCase):
             self.assertTrue(a.equals(b, verbose=3))
 
     def test_geometry_4(self):
-        """TODO DOCS."""
+        """Test nodes all not tied to auxiliary coordinate variables."""
         f = cfdm.read(self.geometry_4_file, verbose=False)
 
         self.assertEqual(len(f), 2, "f = " + repr(f))
@@ -212,7 +212,7 @@ class DSGTest(unittest.TestCase):
         cfdm.write(f, tempfile, verbose=False)
 
     def test_geometry_interior_ring(self):
-        """TODO DOCS."""
+        """Test the management of interior ring geometries."""
         for geometry_file in (
             self.geometry_interior_ring_file,
             self.geometry_interior_ring_file_2,

--- a/cfdm/test/test_geometry.py
+++ b/cfdm/test/test_geometry.py
@@ -34,7 +34,7 @@ atexit.register(_remove_tmpfiles)
 VN = cfdm.CF()
 
 
-class DSGTest(unittest.TestCase):
+class GeometryTest(unittest.TestCase):
     """Test the management of geometry cells."""
 
     def setUp(self):

--- a/cfdm/test/test_groups.py
+++ b/cfdm/test/test_groups.py
@@ -47,7 +47,7 @@ class GroupsTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.LOG_LEVEL("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_groups.py
+++ b/cfdm/test/test_groups.py
@@ -44,7 +44,7 @@ atexit.register(_remove_tmpfiles)
 
 
 class GroupsTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Test treatment of netCDF4 files with hierarchical groups."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -60,7 +60,7 @@ class GroupsTest(unittest.TestCase):
         # cfdm.LOG_LEVEL('DISABLE')
 
     def test_groups(self):
-        """TODO DOCS."""
+        """Test for the general handling of hierarchical groups."""
         f = cfdm.example_field(1)
 
         ungrouped_file = ungrouped_file1
@@ -157,7 +157,7 @@ class GroupsTest(unittest.TestCase):
         self.assertTrue(f.equals(h[0], verbose=2))
 
     def test_groups_geometry(self):
-        """TODO DOCS."""
+        """Test that geometries are considered in the correct groups."""
         f = cfdm.example_field(6)
 
         ungrouped_file = ungrouped_file2
@@ -284,7 +284,7 @@ class GroupsTest(unittest.TestCase):
         self.assertTrue(f.equals(h[0], verbose=2))
 
     def test_groups_compression(self):
-        """TODO DOCS."""
+        """Test the compression of hierarchical groups."""
         f = cfdm.example_field(4)
 
         ungrouped_file = ungrouped_file3
@@ -351,7 +351,7 @@ class GroupsTest(unittest.TestCase):
         self.assertTrue(f.equals(h[0], verbose=2))
 
     def test_groups_dimension(self):
-        """TODO DOCS."""
+        """Test the dimensions of hierarchical groups."""
         f = cfdm.example_field(0)
 
         ungrouped_file = ungrouped_file4
@@ -419,7 +419,7 @@ class GroupsTest(unittest.TestCase):
         self.assertTrue(f.equals(h, verbose=3))
 
     def test_groups_unlimited_dimension(self):
-        """TODO DOCS."""
+        """Test the group behaviour of an unlimited dimension."""
         f = cfdm.example_field(0)
 
         # Create an unlimited dimension in the root group

--- a/cfdm/test/test_netCDF.py
+++ b/cfdm/test/test_netCDF.py
@@ -36,7 +36,7 @@ atexit.register(_remove_tmpfiles)
 
 
 class NetCDFTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Unit test for the NetCDF class."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""

--- a/cfdm/test/test_netCDF.py
+++ b/cfdm/test/test_netCDF.py
@@ -39,7 +39,7 @@ class NetCDFTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_netCDF.py
+++ b/cfdm/test/test_netCDF.py
@@ -71,7 +71,7 @@ class NetCDFTest(unittest.TestCase):
         ]
 
     def test_netCDF_variable_dimension(self):
-        """TODO DOCS."""
+        """Test variable and dimension access NetCDF methods."""
         f = cfdm.Field()
 
         f.nc_set_variable("qwerty")
@@ -251,7 +251,7 @@ class NetCDFTest(unittest.TestCase):
             self.assertTrue(y.equals(x, verbose=3))
 
     def test_netCDF_geometry_variable(self):
-        """TODO DOCS."""
+        """Test geometry variable access and (un)setting methods."""
         f = cfdm.Field()
 
         f.nc_set_geometry_variable("qwerty")
@@ -274,7 +274,7 @@ class NetCDFTest(unittest.TestCase):
                 f.nc_set_geometry_variable(nc_var_name)
 
     def test_netCDF_group_attributes(self):
-        """TODO DOCS."""
+        """Test group attributes access and (un)setting methods."""
         f = cfdm.Field()
 
         attrs = f.nc_group_attributes()
@@ -322,7 +322,7 @@ class NetCDFTest(unittest.TestCase):
         )
 
     def test_netCDF_dimension_groups(self):
-        """TODO DOCS."""
+        """Test dimension groups access and (un)setting methods."""
         d = cfdm.DomainAxis()
 
         d.nc_set_dimension("ncdim")
@@ -378,7 +378,7 @@ class NetCDFTest(unittest.TestCase):
         self.assertFalse(attrs)
 
     def test_netCDF_variable_groups(self):
-        """TODO DOCS."""
+        """Test variable groups access and (un)setting methods."""
         f = cfdm.Field()
 
         f.nc_set_variable("ncdim")
@@ -437,7 +437,7 @@ class NetCDFTest(unittest.TestCase):
             f.nc_set_variable_groups(["forecast", "model"])
 
     def test_netCDF_geometry_variable_groups(self):
-        """TODO DOCS."""
+        """Test geometry variable groups access NetCDF methods."""
         f = cfdm.Field()
 
         f.nc_set_geometry_variable("ncvar")
@@ -496,7 +496,7 @@ class NetCDFTest(unittest.TestCase):
             f.nc_set_geometry_variable_groups(["forecast", "model"])
 
     def test_netCDF_sample_dimension_groups(self):
-        """TODO DOCS."""
+        """Test sample dimension groups access NetCDF methods."""
         c = cfdm.Count()
 
         c.nc_set_sample_dimension("ncvar")
@@ -555,7 +555,7 @@ class NetCDFTest(unittest.TestCase):
             c.nc_set_sample_dimension_groups(["forecast", "model"])
 
     def test_netCDF_field_components(self):
-        """TODO DOCS."""
+        """Test field component access and (un)setting methods."""
         # Geometries
         f = cfdm.example_field(6)
 
@@ -672,7 +672,7 @@ class NetCDFTest(unittest.TestCase):
                 f.nc_clear_component_variable_groups(component)
 
     def test_netCDF_to_memory(self):
-        """TODO DOCS."""
+        """Test the `to_memory` NetCDF method."""
         f = cfdm.example_field(4)
         f.data.to_memory()  # on non-compressed array
         f.compress("indexed_contiguous", inplace=True)

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -47,7 +47,7 @@ atexit.register(_remove_tmpfiles)
 
 
 class read_writeTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Test the reading and writing of field constructs from/to disk."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -81,7 +81,7 @@ class read_writeTest(unittest.TestCase):
         self.netcdf_fmts = self.netcdf3_fmts + self.netcdf4_fmts
 
     def test_write_filename(self):
-        """TODO DOCS."""
+        """Test the writing of a named netCDF file."""
         f = cfdm.example_field(0)
         a = f.data.array
 
@@ -94,7 +94,7 @@ class read_writeTest(unittest.TestCase):
         self.assertTrue((a == g[0].data.array).all())
 
     def test_read_field(self):
-        """TODO DOCS."""
+        """Test the `extra` keyword argument of the `read` function."""
         # Test field keyword of cfdm.read
         filename = self.filename
 
@@ -166,7 +166,7 @@ class read_writeTest(unittest.TestCase):
         self.assertEqual(len(f), 14, "\n" + str(f))
 
     def test_read_write_format(self):
-        """TODO DOCS."""
+        """Test the `fmt` keyword argument of the `read` function."""
         f = cfdm.read(self.filename)[0]
         for fmt in self.netcdf_fmts:
             cfdm.write(f, tmpfile, fmt=fmt)
@@ -434,7 +434,7 @@ class read_writeTest(unittest.TestCase):
             )
 
     def test_read_write_netCDF4_compress_shuffle(self):
-        """TODO DOCS."""
+        """Test the `compress` and `shuffle` parameters to `write`."""
         f = cfdm.read(self.filename)[0]
         for fmt in self.netcdf4_fmts:
             for shuffle in (True,):
@@ -450,7 +450,7 @@ class read_writeTest(unittest.TestCase):
                     )
 
     def test_read_write_missing_data(self):
-        """TODO DOCS."""
+        """Test reading and writing of netCDF with missing data."""
         f = cfdm.read(self.filename)[0]
         for fmt in self.netcdf_fmts:
             cfdm.write(f, tmpfile, fmt=fmt)
@@ -460,7 +460,7 @@ class read_writeTest(unittest.TestCase):
             )
 
     def test_read_mask(self):
-        """TODO DOCS."""
+        """Test reading and writing of netCDF with masked data."""
         f = cfdm.example_field(0)
 
         N = f.size
@@ -496,7 +496,7 @@ class read_writeTest(unittest.TestCase):
         self.assertEqual(numpy.ma.count(g.data.array), N - 2)
 
     def test_write_datatype(self):
-        """TODO DOCS."""
+        """Test the `datatype` keyword argument to `write`."""
         f = cfdm.read(self.filename)[0]
         self.assertEqual(f.data.dtype, numpy.dtype(float))
 
@@ -517,7 +517,7 @@ class read_writeTest(unittest.TestCase):
         )
 
     def test_read_write_unlimited(self):
-        """TODO DOCS."""
+        """Test reading and writing with an unlimited dimension."""
         for fmt in self.netcdf_fmts:
 
             f = cfdm.read(self.filename)[0]
@@ -544,7 +544,7 @@ class read_writeTest(unittest.TestCase):
         self.assertTrue(domain_axes["domainaxis2"].nc_is_unlimited())
 
     def test_read_CDL(self):
-        """TODO DOCS."""
+        """Test the reading of files in CDL format."""
         subprocess.run(
             " ".join(["ncdump", self.filename, ">", tmpfile]),
             shell=True,
@@ -650,7 +650,7 @@ class read_writeTest(unittest.TestCase):
     #        subprocess.run(' '.join(['head', tmpfileh]),  shell=True, check=True)
 
     def test_read_write_string(self):
-        """TODO DOCS."""
+        """Test the `string` keyword argument to `read` and `write`."""
         f = cfdm.read(self.string_filename)
 
         n = int(len(f) / 2)
@@ -685,7 +685,7 @@ class read_writeTest(unittest.TestCase):
                             self.assertTrue(i.equals(j, verbose=3))
 
     def test_read_write_Conventions(self):
-        """TODO DOCS."""
+        """Test the `Conventions` keyword argument to `write`."""
         f = cfdm.read(self.filename)[0]
 
         version = "CF-" + cfdm.CF()
@@ -746,7 +746,7 @@ class read_writeTest(unittest.TestCase):
             )
 
     def test_read_write_multiple_geometries(self):
-        """TODO DOCS."""
+        """Test reading and writing with a mixture of geometry cells."""
         a = []
         for filename in (
             "geometry_1.nc",
@@ -776,7 +776,7 @@ class read_writeTest(unittest.TestCase):
         self.assertFalse(f)
 
     def test_write_coordinates(self):
-        """TODO DOCS."""
+        """Test the `coordinates` keyword argument of `write`."""
         f = cfdm.example_field(0)
 
         cfdm.write(f, tmpfile, coordinates=True)
@@ -786,7 +786,7 @@ class read_writeTest(unittest.TestCase):
         self.assertTrue(g[0].equals(f, verbose=3))
 
     def test_write_scalar_domain_ancillary(self):
-        """TODO DOCS."""
+        """Test the writing of a file with a scalar domain ancillary."""
         f = cfdm.example_field(1)
 
         # Create scalar domain ancillary

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -50,7 +50,7 @@ class read_writeTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.LOG_LEVEL("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_string.py
+++ b/cfdm/test/test_string.py
@@ -37,7 +37,7 @@ class StringTest(unittest.TestCase):
     """TODO DOCS."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         # Disable log messages to silence expected warnings
         cfdm.log_level("DISABLE")
         # Note: to enable all messages for given methods, lines or

--- a/cfdm/test/test_string.py
+++ b/cfdm/test/test_string.py
@@ -34,7 +34,7 @@ atexit.register(_remove_tmpfiles)
 
 
 class StringTest(unittest.TestCase):
-    """TODO DOCS."""
+    """Test constructs with underlying arrays of string data type."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -50,7 +50,7 @@ class StringTest(unittest.TestCase):
         # cfdm.log_level('DISABLE')
 
     def test_STRING(self):
-        """TODO DOCS."""
+        """Test constructs with underlying string type arrays."""
         for array in (
             numpy.ma.array(list("abcdefghij"), dtype="S"),
             numpy.ma.array(

--- a/cfdm/test/test_style.py
+++ b/cfdm/test/test_style.py
@@ -11,7 +11,7 @@ import cfdm
 
 
 class styleTest(unittest.TestCase):
-    """Test PEP8 compliance on all Python files in the codebase."""
+    """Test all Python files against Python style conventions."""
 
     def setUp(self):
         """Preparations called immediately before each test method."""
@@ -34,7 +34,7 @@ class styleTest(unittest.TestCase):
         ]
 
     def test_pep8_compliance(self):
-        """TODO DOCS."""
+        """Test PEP8 compliance on all Python files in the codebase."""
         pep8_check = pycodestyle.StyleGuide()
 
         # Directories to skip in the recursive walk of the directory:

--- a/cfdm/test/test_style.py
+++ b/cfdm/test/test_style.py
@@ -14,7 +14,7 @@ class styleTest(unittest.TestCase):
     """Test PEP8 compliance on all Python files in the codebase."""
 
     def setUp(self):
-        """TODO DOCS."""
+        """Preparations called immediately before each test method."""
         self.cfdm_dir = os.path.dirname(os.path.abspath(__file__))
         os.chdir(self.cfdm_dir)
 


### PR DESCRIPTION
Trivial PR to add the collection of daily commits I have made towards addressing the remaining TODOs for populating empty docstrings (normally I would push these individually as I do them, but I got behind early on in the process of doing these, hence a PR to keep the commit history clean).

In the process of doing this I have noticed, and remedied, that:
* a few test methods were, presumably by copy-and-paste error, duplicates of other (see d5563ef);
* some tests classes had duplicate names (see ab38070 and cc0e4e9) and for safety it was bets to rename these distinctly.
