### PR TITLE
Apply & add hook for isort (systematic import sorting)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,8 +20,8 @@ jobs:
   # *The config. applied here is from our .pre-commit-config.yaml*
   #
   # Note the pre-commit linting includes all of the other linters configured
-  # to run as pre-commit hooks, namely black, flake8, docformatter and
-  # pydocstyle, so there is no need to set these up individually!
+  # to run as pre-commit hooks, namely black, flake8 and docformatter etc.,
+  # so there is no need to set these up individually!
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,19 @@ repos:
     rev: 3.9.1
     hooks:
       - id: flake8
+
+  # Apply the 'isort' tool to sort Python import statements systematically
+  # (see https://pycqa.github.io/isort/ for documentation). It is fully
+  # compatible with 'black' with the lines set to ensure so in the repo's
+  # pyproject.toml. Other than that and the below, no extra config is required.
+  - repo: https://github.com/pycqa/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
+        name: isort (python)
+      - id: isort
+        name: isort (cython)
+        types: [cython]
+      - id: isort
+        name: isort (pyi)
+        types: [pyi]

--- a/cfdm/__init__.py
+++ b/cfdm/__init__.py
@@ -38,7 +38,6 @@ up to the user to use them in a CF-compliant way.
 """
 import logging
 import sys
-
 from distutils.version import LooseVersion
 
 from . import core
@@ -78,86 +77,48 @@ if LooseVersion(netcdf_flattener.__version__) < LooseVersion(_minimum_vn):
         f"at {netcdf_flattener.__file__}"
     )
 
+from .abstract import Container, Implementation
+from .auxiliarycoordinate import AuxiliaryCoordinate
+from .bounds import Bounds
+from .cellmeasure import CellMeasure
+from .cellmethod import CellMethod
+from .cfdmimplementation import CFDMImplementation, implementation
 from .constants import masked
-
-# Internal ones passed on so they can be used in cf-python (see
-# comment below)
-from .functions import (
-    ATOL,
-    CF,
-    LOG_LEVEL,
-    RTOL,
-    abspath,
-    atol,
-    configuration,
-    environment,
-    log_level,
-    rtol,
-    _disable_logging,
-    _reset_log_emergence_level,
-    _is_valid_log_level_int,
-    Configuration,
-    Constant,
-    ConstantAccess,
-    is_log_level_debug,
-    is_log_level_detail,
-    is_log_level_info,
-)
-
+from .constructs import Constructs
+from .coordinateconversion import CoordinateConversion
+from .coordinatereference import CoordinateReference
+from .count import Count
+from .data import (Array, CompressedArray, Data, GatheredArray, NetCDFArray,
+                   NumpyArray, RaggedContiguousArray, RaggedIndexedArray,
+                   RaggedIndexedContiguousArray)
+from .datum import Datum
 # Though these are internal-use methods, include them in the namespace
 # (without documenting them) so that cf-python can use them internally
 # too:
-from .decorators import (
-    _inplace_enabled,
-    _inplace_enabled_define_and_cleanup,
-    _manage_log_level_via_verbosity,
-    _display_or_return,
-)
-
-from .constructs import Constructs
-
-from .data import (
-    Data,
-    Array,
-    CompressedArray,
-    NumpyArray,
-    NetCDFArray,
-    GatheredArray,
-    RaggedContiguousArray,
-    RaggedIndexedArray,
-    RaggedIndexedContiguousArray,
-)
-
-from .count import Count
+from .decorators import (_display_or_return, _inplace_enabled,
+                         _inplace_enabled_define_and_cleanup,
+                         _manage_log_level_via_verbosity)
+from .dimensioncoordinate import DimensionCoordinate
+from .domain import Domain
+from .domainancillary import DomainAncillary
+from .domainaxis import DomainAxis
+from .examplefield import example_domain, example_field, example_fields
+from .field import Field
+from .fieldancillary import FieldAncillary
+# Internal ones passed on so they can be used in cf-python (see
+# comment below)
+from .functions import (ATOL, CF, LOG_LEVEL, RTOL, Configuration, Constant,
+                        ConstantAccess, _disable_logging,
+                        _is_valid_log_level_int, _reset_log_emergence_level,
+                        abspath, atol, configuration, environment,
+                        is_log_level_debug, is_log_level_detail,
+                        is_log_level_info, log_level, rtol)
 from .index import Index
+from .interiorring import InteriorRing
 from .list import List
 from .nodecountproperties import NodeCountProperties
 from .partnodecountproperties import PartNodeCountProperties
-
-from .bounds import Bounds
-from .coordinateconversion import CoordinateConversion
-from .datum import Datum
-from .domain import Domain
-from .interiorring import InteriorRing
-
-from .auxiliarycoordinate import AuxiliaryCoordinate
-from .cellmeasure import CellMeasure
-from .cellmethod import CellMethod
-from .coordinatereference import CoordinateReference
-from .dimensioncoordinate import DimensionCoordinate
-from .domainancillary import DomainAncillary
-from .domainaxis import DomainAxis
-from .field import Field
-from .fieldancillary import FieldAncillary
-
-from .abstract import Implementation
-from .cfdmimplementation import CFDMImplementation, implementation
-
 from .read_write import read, write
-
-from .examplefield import example_field, example_fields, example_domain
-
-from .abstract import Container
 
 # --------------------------------------------------------------------
 # Set up basic logging for the full project with a root logger

--- a/cfdm/__init__.py
+++ b/cfdm/__init__.py
@@ -38,6 +38,7 @@ up to the user to use them in a CF-compliant way.
 """
 import logging
 import sys
+
 from distutils.version import LooseVersion
 
 from . import core
@@ -77,48 +78,86 @@ if LooseVersion(netcdf_flattener.__version__) < LooseVersion(_minimum_vn):
         f"at {netcdf_flattener.__file__}"
     )
 
-from .abstract import Container, Implementation
-from .auxiliarycoordinate import AuxiliaryCoordinate
-from .bounds import Bounds
-from .cellmeasure import CellMeasure
-from .cellmethod import CellMethod
-from .cfdmimplementation import CFDMImplementation, implementation
 from .constants import masked
-from .constructs import Constructs
-from .coordinateconversion import CoordinateConversion
-from .coordinatereference import CoordinateReference
-from .count import Count
-from .data import (Array, CompressedArray, Data, GatheredArray, NetCDFArray,
-                   NumpyArray, RaggedContiguousArray, RaggedIndexedArray,
-                   RaggedIndexedContiguousArray)
-from .datum import Datum
+
+# Internal ones passed on so they can be used in cf-python (see
+# comment below)
+from .functions import (
+    ATOL,
+    CF,
+    LOG_LEVEL,
+    RTOL,
+    abspath,
+    atol,
+    configuration,
+    environment,
+    log_level,
+    rtol,
+    _disable_logging,
+    _reset_log_emergence_level,
+    _is_valid_log_level_int,
+    Configuration,
+    Constant,
+    ConstantAccess,
+    is_log_level_debug,
+    is_log_level_detail,
+    is_log_level_info,
+)
+
 # Though these are internal-use methods, include them in the namespace
 # (without documenting them) so that cf-python can use them internally
 # too:
-from .decorators import (_display_or_return, _inplace_enabled,
-                         _inplace_enabled_define_and_cleanup,
-                         _manage_log_level_via_verbosity)
-from .dimensioncoordinate import DimensionCoordinate
-from .domain import Domain
-from .domainancillary import DomainAncillary
-from .domainaxis import DomainAxis
-from .examplefield import example_domain, example_field, example_fields
-from .field import Field
-from .fieldancillary import FieldAncillary
-# Internal ones passed on so they can be used in cf-python (see
-# comment below)
-from .functions import (ATOL, CF, LOG_LEVEL, RTOL, Configuration, Constant,
-                        ConstantAccess, _disable_logging,
-                        _is_valid_log_level_int, _reset_log_emergence_level,
-                        abspath, atol, configuration, environment,
-                        is_log_level_debug, is_log_level_detail,
-                        is_log_level_info, log_level, rtol)
+from .decorators import (
+    _inplace_enabled,
+    _inplace_enabled_define_and_cleanup,
+    _manage_log_level_via_verbosity,
+    _display_or_return,
+)
+
+from .constructs import Constructs
+
+from .data import (
+    Data,
+    Array,
+    CompressedArray,
+    NumpyArray,
+    NetCDFArray,
+    GatheredArray,
+    RaggedContiguousArray,
+    RaggedIndexedArray,
+    RaggedIndexedContiguousArray,
+)
+
+from .count import Count
 from .index import Index
-from .interiorring import InteriorRing
 from .list import List
 from .nodecountproperties import NodeCountProperties
 from .partnodecountproperties import PartNodeCountProperties
+
+from .bounds import Bounds
+from .coordinateconversion import CoordinateConversion
+from .datum import Datum
+from .domain import Domain
+from .interiorring import InteriorRing
+
+from .auxiliarycoordinate import AuxiliaryCoordinate
+from .cellmeasure import CellMeasure
+from .cellmethod import CellMethod
+from .coordinatereference import CoordinateReference
+from .dimensioncoordinate import DimensionCoordinate
+from .domainancillary import DomainAncillary
+from .domainaxis import DomainAxis
+from .field import Field
+from .fieldancillary import FieldAncillary
+
+from .abstract import Implementation
+from .cfdmimplementation import CFDMImplementation, implementation
+
 from .read_write import read, write
+
+from .examplefield import example_field, example_fields, example_domain
+
+from .abstract import Container
 
 # --------------------------------------------------------------------
 # Set up basic logging for the full project with a root logger

--- a/cfdm/abstract/container.py
+++ b/cfdm/abstract/container.py
@@ -1,5 +1,4 @@
-from .. import core
-from .. import mixin
+from .. import core, mixin
 
 
 class Container(mixin.Container, core.abstract.Container):

--- a/cfdm/auxiliarycoordinate.py
+++ b/cfdm/auxiliarycoordinate.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class AuxiliaryCoordinate(

--- a/cfdm/bounds.py
+++ b/cfdm/bounds.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class Bounds(

--- a/cfdm/cellmeasure.py
+++ b/cfdm/cellmeasure.py
@@ -1,10 +1,7 @@
 import logging
 
-from . import mixin
-from . import core
-
+from . import core, mixin
 from .decorators import _manage_log_level_via_verbosity
-
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/cellmethod.py
+++ b/cfdm/cellmethod.py
@@ -1,16 +1,11 @@
 import logging
-
 from copy import deepcopy
 
 import numpy
 
+from . import core, mixin
 from .data import Data
-
-from . import mixin
-from . import core
-
 from .decorators import _manage_log_level_via_verbosity
-
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -1,11 +1,33 @@
-from . import (CF, AuxiliaryCoordinate, Bounds, CellMeasure, CellMethod,
-               CoordinateConversion, CoordinateReference, Count, Datum,
-               DimensionCoordinate, DomainAncillary, DomainAxis, Field,
-               FieldAncillary, Index, InteriorRing, List, NodeCountProperties,
-               PartNodeCountProperties)
+from . import (
+    CF,
+    AuxiliaryCoordinate,
+    Bounds,
+    CellMeasure,
+    CellMethod,
+    CoordinateConversion,
+    CoordinateReference,
+    Count,
+    Datum,
+    DimensionCoordinate,
+    DomainAncillary,
+    DomainAxis,
+    Field,
+    FieldAncillary,
+    Index,
+    InteriorRing,
+    List,
+    NodeCountProperties,
+    PartNodeCountProperties,
+)
 from .abstract import Implementation
-from .data import (Data, GatheredArray, NetCDFArray, RaggedContiguousArray,
-                   RaggedIndexedArray, RaggedIndexedContiguousArray)
+from .data import (
+    Data,
+    GatheredArray,
+    NetCDFArray,
+    RaggedContiguousArray,
+    RaggedIndexedArray,
+    RaggedIndexedContiguousArray,
+)
 
 
 class CFDMImplementation(Implementation):

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -1,36 +1,11 @@
-from . import (
-    AuxiliaryCoordinate,
-    CellMethod,
-    CellMeasure,
-    CoordinateReference,
-    DimensionCoordinate,
-    DomainAncillary,
-    DomainAxis,
-    Field,
-    FieldAncillary,
-    Bounds,
-    InteriorRing,
-    CoordinateConversion,
-    Datum,
-    Count,
-    List,
-    Index,
-    NodeCountProperties,
-    PartNodeCountProperties,
-)
-
-from .data import (
-    Data,
-    GatheredArray,
-    NetCDFArray,
-    RaggedContiguousArray,
-    RaggedIndexedArray,
-    RaggedIndexedContiguousArray,
-)
-
+from . import (CF, AuxiliaryCoordinate, Bounds, CellMeasure, CellMethod,
+               CoordinateConversion, CoordinateReference, Count, Datum,
+               DimensionCoordinate, DomainAncillary, DomainAxis, Field,
+               FieldAncillary, Index, InteriorRing, List, NodeCountProperties,
+               PartNodeCountProperties)
 from .abstract import Implementation
-
-from . import CF
+from .data import (Data, GatheredArray, NetCDFArray, RaggedContiguousArray,
+                   RaggedIndexedArray, RaggedIndexedContiguousArray)
 
 
 class CFDMImplementation(Implementation):

--- a/cfdm/constants.py
+++ b/cfdm/constants.py
@@ -1,10 +1,8 @@
 import logging
 import sys
-
 from enum import Enum
 
 import numpy
-
 
 """A dictionary of useful constants.
 

--- a/cfdm/constructs.py
+++ b/cfdm/constructs.py
@@ -1,5 +1,4 @@
 import logging
-
 from itertools import zip_longest
 
 # TODO - replace the try block with "from re import Pattern" when
@@ -11,12 +10,9 @@ except ImportError:  # pragma: no cover
 else:
     python36 = False
 
-from . import core
-from . import mixin
-
-from .decorators import _manage_log_level_via_verbosity
+from . import core, mixin
 from .core.functions import deepcopy
-
+from .decorators import _manage_log_level_via_verbosity
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/coordinateconversion.py
+++ b/cfdm/coordinateconversion.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class CoordinateConversion(

--- a/cfdm/coordinatereference.py
+++ b/cfdm/coordinatereference.py
@@ -1,14 +1,8 @@
 import logging
 
-from . import mixin
-from . import core
-from . import CoordinateConversion
-from . import Datum
-
+from . import CoordinateConversion, Datum, core, mixin
 from .data import Data
-
-from .decorators import _manage_log_level_via_verbosity, _display_or_return
-
+from .decorators import _display_or_return, _manage_log_level_via_verbosity
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/core/__init__.py
+++ b/cfdm/core/__init__.py
@@ -4,8 +4,8 @@ __date__ = "2021-05-25"
 __cf_version__ = "1.8"
 __version__ = "1.8.9.0"
 
-import platform
 from distutils.version import LooseVersion
+import platform
 
 _requires = (
     "numpy",
@@ -48,24 +48,36 @@ if LooseVersion(numpy.__version__) < LooseVersion(_minimum_vn):
         f"Got {numpy.__version__} at {numpy.__file__}"
     )
 
-from .abstract import (Container, Coordinate, Parameters,
-                       ParametersDomainAncillaries, Properties, PropertiesData,
-                       PropertiesDataBounds)
-from .auxiliarycoordinate import AuxiliaryCoordinate
+from .constructs import Constructs
+
+from .functions import CF, environment
+
+from .data import Data, Array, NumpyArray
+
 from .bounds import Bounds
+from .coordinateconversion import CoordinateConversion
+from .datum import Datum
+from .domain import Domain
+from .interiorring import InteriorRing
+
+from .auxiliarycoordinate import AuxiliaryCoordinate
 from .cellmeasure import CellMeasure
 from .cellmethod import CellMethod
-from .constructs import Constructs
-from .coordinateconversion import CoordinateConversion
 from .coordinatereference import CoordinateReference
-from .data import Array, Data, NumpyArray
-from .datum import Datum
 from .dimensioncoordinate import DimensionCoordinate
-from .domain import Domain
 from .domainancillary import DomainAncillary
 from .domainaxis import DomainAxis
 from .field import Field
 from .fieldancillary import FieldAncillary
-from .functions import CF, environment
-from .interiorring import InteriorRing
+
+from .abstract import (
+    Container,
+    Properties,
+    PropertiesData,
+    PropertiesDataBounds,
+    Coordinate,
+    Parameters,
+    ParametersDomainAncillaries,
+)
+
 from .meta import DocstringRewriteMeta

--- a/cfdm/core/__init__.py
+++ b/cfdm/core/__init__.py
@@ -4,8 +4,8 @@ __date__ = "2021-05-25"
 __cf_version__ = "1.8"
 __version__ = "1.8.9.0"
 
-from distutils.version import LooseVersion
 import platform
+from distutils.version import LooseVersion
 
 _requires = (
     "numpy",
@@ -48,36 +48,24 @@ if LooseVersion(numpy.__version__) < LooseVersion(_minimum_vn):
         f"Got {numpy.__version__} at {numpy.__file__}"
     )
 
-from .constructs import Constructs
-
-from .functions import CF, environment
-
-from .data import Data, Array, NumpyArray
-
-from .bounds import Bounds
-from .coordinateconversion import CoordinateConversion
-from .datum import Datum
-from .domain import Domain
-from .interiorring import InteriorRing
-
+from .abstract import (Container, Coordinate, Parameters,
+                       ParametersDomainAncillaries, Properties, PropertiesData,
+                       PropertiesDataBounds)
 from .auxiliarycoordinate import AuxiliaryCoordinate
+from .bounds import Bounds
 from .cellmeasure import CellMeasure
 from .cellmethod import CellMethod
+from .constructs import Constructs
+from .coordinateconversion import CoordinateConversion
 from .coordinatereference import CoordinateReference
+from .data import Array, Data, NumpyArray
+from .datum import Datum
 from .dimensioncoordinate import DimensionCoordinate
+from .domain import Domain
 from .domainancillary import DomainAncillary
 from .domainaxis import DomainAxis
 from .field import Field
 from .fieldancillary import FieldAncillary
-
-from .abstract import (
-    Container,
-    Properties,
-    PropertiesData,
-    PropertiesDataBounds,
-    Coordinate,
-    Parameters,
-    ParametersDomainAncillaries,
-)
-
+from .functions import CF, environment
+from .interiorring import InteriorRing
 from .meta import DocstringRewriteMeta

--- a/cfdm/core/abstract/__init__.py
+++ b/cfdm/core/abstract/__init__.py
@@ -1,7 +1,9 @@
 from .container import Container
-from .coordinate import Coordinate
-from .parameters import Parameters
-from .parametersdomainancillaries import ParametersDomainAncillaries
+
 from .properties import Properties
 from .propertiesdata import PropertiesData
 from .propertiesdatabounds import PropertiesDataBounds
+from .coordinate import Coordinate
+
+from .parameters import Parameters
+from .parametersdomainancillaries import ParametersDomainAncillaries

--- a/cfdm/core/abstract/__init__.py
+++ b/cfdm/core/abstract/__init__.py
@@ -1,9 +1,7 @@
 from .container import Container
-
+from .coordinate import Coordinate
+from .parameters import Parameters
+from .parametersdomainancillaries import ParametersDomainAncillaries
 from .properties import Properties
 from .propertiesdata import PropertiesData
 from .propertiesdatabounds import PropertiesDataBounds
-from .coordinate import Coordinate
-
-from .parameters import Parameters
-from .parametersdomainancillaries import ParametersDomainAncillaries

--- a/cfdm/core/abstract/container.py
+++ b/cfdm/core/abstract/container.py
@@ -1,8 +1,6 @@
-from ..meta import DocstringRewriteMeta
-
 from ..docstring import _docstring_substitution_definitions
-
 from ..functions import deepcopy
+from ..meta import DocstringRewriteMeta
 
 
 class Container(metaclass=DocstringRewriteMeta):

--- a/cfdm/core/abstract/parameters.py
+++ b/cfdm/core/abstract/parameters.py
@@ -1,6 +1,5 @@
-from .container import Container
-
 from ..functions import deepcopy
+from .container import Container
 
 
 class Parameters(Container):

--- a/cfdm/core/abstract/properties.py
+++ b/cfdm/core/abstract/properties.py
@@ -1,6 +1,5 @@
-from .container import Container
-
 from ..functions import deepcopy
+from .container import Container
 
 
 class Properties(Container):

--- a/cfdm/core/abstract/propertiesdata.py
+++ b/cfdm/core/abstract/propertiesdata.py
@@ -1,5 +1,4 @@
 from ..data import Data
-
 from .properties import Properties
 
 

--- a/cfdm/core/abstract/propertiesdatabounds.py
+++ b/cfdm/core/abstract/propertiesdatabounds.py
@@ -2,7 +2,6 @@ import numpy
 
 from .propertiesdata import PropertiesData
 
-
 # --------------------------------------------------------------------
 # See cfdm.core.mixin.container.__docstring_substitution__ for {{...}}
 # docstring substitutions

--- a/cfdm/core/coordinatereference.py
+++ b/cfdm/core/coordinatereference.py
@@ -1,7 +1,4 @@
-from . import abstract
-
-from . import CoordinateConversion
-from . import Datum
+from . import CoordinateConversion, Datum, abstract
 
 
 class CoordinateReference(abstract.Container):

--- a/cfdm/core/data/__init__.py
+++ b/cfdm/core/data/__init__.py
@@ -1,3 +1,3 @@
 from .abstract import Array
-from .numpyarray import NumpyArray
 from .data import Data
+from .numpyarray import NumpyArray

--- a/cfdm/core/data/__init__.py
+++ b/cfdm/core/data/__init__.py
@@ -1,3 +1,3 @@
 from .abstract import Array
-from .data import Data
 from .numpyarray import NumpyArray
+from .data import Data

--- a/cfdm/core/data/data.py
+++ b/cfdm/core/data/data.py
@@ -1,7 +1,6 @@
 import numpy
 
 from .. import abstract
-
 from .abstract import Array
 from .numpyarray import NumpyArray
 

--- a/cfdm/core/domain.py
+++ b/cfdm/core/domain.py
@@ -1,7 +1,4 @@
-from . import abstract
-from . import mixin
-
-from . import Constructs
+from . import Constructs, abstract, mixin
 
 
 class Domain(mixin.FieldDomain, abstract.Container):

--- a/cfdm/core/field.py
+++ b/cfdm/core/field.py
@@ -1,10 +1,6 @@
 import numpy
 
-from . import abstract
-from . import mixin
-
-from . import Constructs
-from . import Domain
+from . import Constructs, Domain, abstract, mixin
 
 
 class Field(mixin.FieldDomain, abstract.PropertiesData):

--- a/cfdm/core/functions.py
+++ b/cfdm/core/functions.py
@@ -1,13 +1,12 @@
 import os
 import platform
 import sys
-
 from pickle import dumps, loads
 
 import netCDF4
 import numpy
 
-from . import __version__, __cf_version__, __file__
+from . import __cf_version__, __file__, __version__
 
 
 def environment(display=True, paths=True):

--- a/cfdm/core/meta/docstringrewrite.py
+++ b/cfdm/core/meta/docstringrewrite.py
@@ -2,7 +2,6 @@ import inspect
 
 from ..functions import CF
 
-
 _VN = CF()
 
 

--- a/cfdm/count.py
+++ b/cfdm/count.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class Count(

--- a/cfdm/data/__init__.py
+++ b/cfdm/data/__init__.py
@@ -1,10 +1,8 @@
 from .abstract import Array, CompressedArray
-
+from .data import Data
 from .gatheredarray import GatheredArray
 from .netcdfarray import NetCDFArray
 from .numpyarray import NumpyArray
 from .raggedcontiguousarray import RaggedContiguousArray
 from .raggedindexedarray import RaggedIndexedArray
 from .raggedindexedcontiguousarray import RaggedIndexedContiguousArray
-
-from .data import Data

--- a/cfdm/data/__init__.py
+++ b/cfdm/data/__init__.py
@@ -1,8 +1,10 @@
 from .abstract import Array, CompressedArray
-from .data import Data
+
 from .gatheredarray import GatheredArray
 from .netcdfarray import NetCDFArray
 from .numpyarray import NumpyArray
 from .raggedcontiguousarray import RaggedContiguousArray
 from .raggedindexedarray import RaggedIndexedArray
 from .raggedindexedcontiguousarray import RaggedIndexedContiguousArray
+
+from .data import Data

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -1,26 +1,18 @@
 import itertools
 import logging
 
-import numpy
 import netCDF4
+import numpy
 
 from .. import core
-
+from ..constants import masked as cfdm_masked
+from ..decorators import (_inplace_enabled,
+                          _inplace_enabled_define_and_cleanup,
+                          _manage_log_level_via_verbosity)
+from ..functions import abspath
 from ..mixin.container import Container
 from ..mixin.netcdf import NetCDFHDF5
-
-from ..constants import masked as cfdm_masked
-from ..functions import abspath
-
-from ..decorators import (
-    _inplace_enabled,
-    _inplace_enabled_define_and_cleanup,
-    _manage_log_level_via_verbosity,
-)
-
-from . import abstract
-from . import NumpyArray
-
+from . import NumpyArray, abstract
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -6,9 +6,11 @@ import numpy
 
 from .. import core
 from ..constants import masked as cfdm_masked
-from ..decorators import (_inplace_enabled,
-                          _inplace_enabled_define_and_cleanup,
-                          _manage_log_level_via_verbosity)
+from ..decorators import (
+    _inplace_enabled,
+    _inplace_enabled_define_and_cleanup,
+    _manage_log_level_via_verbosity,
+)
 from ..functions import abspath
 from ..mixin.container import Container
 from ..mixin.netcdf import NetCDFHDF5

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -1,8 +1,7 @@
-import numpy
 import netCDF4
+import numpy
 
 from . import abstract
-
 from .numpyarray import NumpyArray
 
 

--- a/cfdm/data/numpyarray.py
+++ b/cfdm/data/numpyarray.py
@@ -1,6 +1,5 @@
-from .mixin import ArrayMixin
-
 from .. import core
+from .mixin import ArrayMixin
 
 
 class NumpyArray(ArrayMixin, core.NumpyArray):

--- a/cfdm/data/raggedcontiguousarray.py
+++ b/cfdm/data/raggedcontiguousarray.py
@@ -1,7 +1,6 @@
 import numpy
 
-from . import abstract
-from . import mixin
+from . import abstract, mixin
 
 
 class RaggedContiguousArray(mixin.RaggedContiguous, abstract.CompressedArray):

--- a/cfdm/data/raggedindexedarray.py
+++ b/cfdm/data/raggedindexedarray.py
@@ -1,7 +1,6 @@
 import numpy
 
-from . import abstract
-from . import mixin
+from . import abstract, mixin
 
 
 class RaggedIndexedArray(mixin.RaggedIndexed, abstract.CompressedArray):

--- a/cfdm/data/raggedindexedcontiguousarray.py
+++ b/cfdm/data/raggedindexedcontiguousarray.py
@@ -1,7 +1,6 @@
 import numpy
 
-from . import abstract
-from . import mixin
+from . import abstract, mixin
 
 
 class RaggedIndexedContiguousArray(

--- a/cfdm/datum.py
+++ b/cfdm/datum.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class Datum(mixin.Parameters, mixin.NetCDFVariable, core.Datum):

--- a/cfdm/decorators.py
+++ b/cfdm/decorators.py
@@ -1,17 +1,8 @@
-from functools import (
-    wraps,
-    partial,
-)
-
-from .functions import (
-    log_level,
-    _disable_logging,
-    _reset_log_emergence_level,
-    _is_valid_log_level_int,
-)
+from functools import partial, wraps
 
 from .constants import ValidLogLevels
-
+from .functions import (_disable_logging, _is_valid_log_level_int,
+                        _reset_log_emergence_level, log_level)
 
 # Identifier for '_inplace_enabled' to use as a (temporary) attribute name
 INPLACE_ENABLED_PLACEHOLDER = "_inplace_store"

--- a/cfdm/decorators.py
+++ b/cfdm/decorators.py
@@ -1,8 +1,12 @@
 from functools import partial, wraps
 
 from .constants import ValidLogLevels
-from .functions import (_disable_logging, _is_valid_log_level_int,
-                        _reset_log_emergence_level, log_level)
+from .functions import (
+    _disable_logging,
+    _is_valid_log_level_int,
+    _reset_log_emergence_level,
+    log_level,
+)
 
 # Identifier for '_inplace_enabled' to use as a (temporary) attribute name
 INPLACE_ENABLED_PLACEHOLDER = "_inplace_store"

--- a/cfdm/dimensioncoordinate.py
+++ b/cfdm/dimensioncoordinate.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class DimensionCoordinate(

--- a/cfdm/domain.py
+++ b/cfdm/domain.py
@@ -1,17 +1,9 @@
 import logging
 
-from . import mixin
-from . import core
-
-from . import Constructs
-
-from .decorators import (
-    _display_or_return,
-    _inplace_enabled,
-    _inplace_enabled_define_and_cleanup,
-    _manage_log_level_via_verbosity,
-)
-
+from . import Constructs, core, mixin
+from .decorators import (_display_or_return, _inplace_enabled,
+                         _inplace_enabled_define_and_cleanup,
+                         _manage_log_level_via_verbosity)
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/domain.py
+++ b/cfdm/domain.py
@@ -1,9 +1,12 @@
 import logging
 
 from . import Constructs, core, mixin
-from .decorators import (_display_or_return, _inplace_enabled,
-                         _inplace_enabled_define_and_cleanup,
-                         _manage_log_level_via_verbosity)
+from .decorators import (
+    _display_or_return,
+    _inplace_enabled,
+    _inplace_enabled_define_and_cleanup,
+    _manage_log_level_via_verbosity,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/domainancillary.py
+++ b/cfdm/domainancillary.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class DomainAncillary(

--- a/cfdm/domainaxis.py
+++ b/cfdm/domainaxis.py
@@ -1,10 +1,7 @@
 import logging
 
-from . import mixin
-from . import core
-
+from . import core, mixin
 from .decorators import _manage_log_level_via_verbosity
-
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/examplefield.py
+++ b/cfdm/examplefield.py
@@ -1,7 +1,5 @@
-from .functions import CF
-
 from .cfdmimplementation import implementation
-
+from .functions import CF
 
 _implementation = implementation()
 

--- a/cfdm/field.py
+++ b/cfdm/field.py
@@ -2,11 +2,19 @@ import logging
 
 from . import Constructs, Count, Domain, Index, List, core, mixin
 from .constants import masked as cfdm_masked
-from .data import (GatheredArray, RaggedContiguousArray, RaggedIndexedArray,
-                   RaggedIndexedContiguousArray)
-from .decorators import (_display_or_return, _inplace_enabled,
-                         _inplace_enabled_define_and_cleanup,
-                         _manage_log_level_via_verbosity, _test_decorator_args)
+from .data import (
+    GatheredArray,
+    RaggedContiguousArray,
+    RaggedIndexedArray,
+    RaggedIndexedContiguousArray,
+)
+from .decorators import (
+    _display_or_return,
+    _inplace_enabled,
+    _inplace_enabled_define_and_cleanup,
+    _manage_log_level_via_verbosity,
+    _test_decorator_args,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/field.py
+++ b/cfdm/field.py
@@ -1,30 +1,12 @@
 import logging
 
-from . import mixin
-from . import core
-from . import Constructs
-from . import Domain
-from . import Count
-from . import Index
-from . import List
-
+from . import Constructs, Count, Domain, Index, List, core, mixin
 from .constants import masked as cfdm_masked
-
-from .data import (
-    RaggedContiguousArray,
-    RaggedIndexedArray,
-    RaggedIndexedContiguousArray,
-    GatheredArray,
-)
-
-from .decorators import (
-    _inplace_enabled,
-    _inplace_enabled_define_and_cleanup,
-    _manage_log_level_via_verbosity,
-    _test_decorator_args,
-    _display_or_return,
-)
-
+from .data import (GatheredArray, RaggedContiguousArray, RaggedIndexedArray,
+                   RaggedIndexedContiguousArray)
+from .decorators import (_display_or_return, _inplace_enabled,
+                         _inplace_enabled_define_and_cleanup,
+                         _manage_log_level_via_verbosity, _test_decorator_args)
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/fieldancillary.py
+++ b/cfdm/fieldancillary.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class FieldAncillary(

--- a/cfdm/functions.py
+++ b/cfdm/functions.py
@@ -1,28 +1,19 @@
 import logging
 import os
 import urllib.parse
-
 from copy import deepcopy
-
 from functools import total_ordering
 
 import cftime
 import netcdf_flattener
 
-from . import core
-
-from . import __version__, __cf_version__, __file__
-
-from .core import DocstringRewriteMeta
-
-from .core.docstring import (
-    _docstring_substitution_definitions as _core_docstring_substitution_definitions,
-)
-
-from .docstring import _docstring_substitution_definitions
-
+from . import __cf_version__, __file__, __version__, core
 from .constants import CONSTANTS, ValidLogLevels
-
+from .core import DocstringRewriteMeta
+from .core.docstring import \
+    _docstring_substitution_definitions as \
+    _core_docstring_substitution_definitions
+from .docstring import _docstring_substitution_definitions
 
 # --------------------------------------------------------------------
 # Merge core and non-core docstring substitution dictionaries without

--- a/cfdm/functions.py
+++ b/cfdm/functions.py
@@ -10,9 +10,9 @@ import netcdf_flattener
 from . import __cf_version__, __file__, __version__, core
 from .constants import CONSTANTS, ValidLogLevels
 from .core import DocstringRewriteMeta
-from .core.docstring import \
-    _docstring_substitution_definitions as \
-    _core_docstring_substitution_definitions
+from .core.docstring import (
+    _docstring_substitution_definitions as _core_docstring_substitution_definitions,
+)
 from .docstring import _docstring_substitution_definitions
 
 # --------------------------------------------------------------------

--- a/cfdm/index.py
+++ b/cfdm/index.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class Index(

--- a/cfdm/interiorring.py
+++ b/cfdm/interiorring.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class InteriorRing(

--- a/cfdm/list.py
+++ b/cfdm/list.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class List(

--- a/cfdm/mixin/__init__.py
+++ b/cfdm/mixin/__init__.py
@@ -1,13 +1,24 @@
 from .container import Container
-from .coordinate import Coordinate
-from .fielddomain import FieldDomain
-from .netcdf import (NetCDFComponents, NetCDFDimension, NetCDFExternal,
-                     NetCDFGeometry, NetCDFGlobalAttributes,
-                     NetCDFGroupAttributes, NetCDFHDF5, NetCDFSampleDimension,
-                     NetCDFUnlimitedDimension, NetCDFUnreferenced,
-                     NetCDFVariable)
-from .parameters import Parameters
-from .parametersdomainancillaries import ParametersDomainAncillaries
 from .properties import Properties
 from .propertiesdata import PropertiesData
 from .propertiesdatabounds import PropertiesDataBounds
+from .coordinate import Coordinate
+
+from .parameters import Parameters
+from .parametersdomainancillaries import ParametersDomainAncillaries
+
+from .netcdf import (
+    NetCDFComponents,
+    NetCDFGlobalAttributes,
+    NetCDFGroupAttributes,
+    NetCDFUnlimitedDimension,
+    NetCDFDimension,
+    NetCDFExternal,
+    NetCDFGeometry,
+    NetCDFHDF5,
+    NetCDFSampleDimension,
+    NetCDFUnreferenced,
+    NetCDFVariable,
+)
+
+from .fielddomain import FieldDomain

--- a/cfdm/mixin/__init__.py
+++ b/cfdm/mixin/__init__.py
@@ -1,24 +1,13 @@
 from .container import Container
+from .coordinate import Coordinate
+from .fielddomain import FieldDomain
+from .netcdf import (NetCDFComponents, NetCDFDimension, NetCDFExternal,
+                     NetCDFGeometry, NetCDFGlobalAttributes,
+                     NetCDFGroupAttributes, NetCDFHDF5, NetCDFSampleDimension,
+                     NetCDFUnlimitedDimension, NetCDFUnreferenced,
+                     NetCDFVariable)
+from .parameters import Parameters
+from .parametersdomainancillaries import ParametersDomainAncillaries
 from .properties import Properties
 from .propertiesdata import PropertiesData
 from .propertiesdatabounds import PropertiesDataBounds
-from .coordinate import Coordinate
-
-from .parameters import Parameters
-from .parametersdomainancillaries import ParametersDomainAncillaries
-
-from .netcdf import (
-    NetCDFComponents,
-    NetCDFGlobalAttributes,
-    NetCDFGroupAttributes,
-    NetCDFUnlimitedDimension,
-    NetCDFDimension,
-    NetCDFExternal,
-    NetCDFGeometry,
-    NetCDFHDF5,
-    NetCDFSampleDimension,
-    NetCDFUnreferenced,
-    NetCDFVariable,
-)
-
-from .fielddomain import FieldDomain

--- a/cfdm/mixin/container.py
+++ b/cfdm/mixin/container.py
@@ -2,12 +2,9 @@ import logging
 
 import numpy
 
-from ..functions import atol, rtol
-
 from ..decorators import _manage_log_level_via_verbosity
-
 from ..docstring import _docstring_substitution_definitions
-
+from ..functions import atol, rtol
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/mixin/fielddomain.py
+++ b/cfdm/mixin/fielddomain.py
@@ -1,7 +1,6 @@
 import logging
 import re
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/cfdm/mixin/parameters.py
+++ b/cfdm/mixin/parameters.py
@@ -1,9 +1,7 @@
 import logging
 
-from . import Container
-
 from ..decorators import _manage_log_level_via_verbosity
-
+from . import Container
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/mixin/parametersdomainancillaries.py
+++ b/cfdm/mixin/parametersdomainancillaries.py
@@ -1,9 +1,7 @@
 import logging
 
-from . import Parameters
-
 from ..decorators import _manage_log_level_via_verbosity
-
+from . import Parameters
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/mixin/properties.py
+++ b/cfdm/mixin/properties.py
@@ -1,10 +1,8 @@
 import logging
 import textwrap
 
+from ..decorators import _display_or_return, _manage_log_level_via_verbosity
 from . import Container
-
-from ..decorators import _manage_log_level_via_verbosity, _display_or_return
-
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/mixin/propertiesdata.py
+++ b/cfdm/mixin/propertiesdata.py
@@ -1,10 +1,13 @@
 import logging
 
 from ..data import Data
-from ..decorators import (_display_or_return, _inplace_enabled,
-                          _inplace_enabled_define_and_cleanup,
-                          _manage_log_level_via_verbosity,
-                          _test_decorator_args)
+from ..decorators import (
+    _display_or_return,
+    _inplace_enabled,
+    _inplace_enabled_define_and_cleanup,
+    _manage_log_level_via_verbosity,
+    _test_decorator_args,
+)
 from . import Properties
 
 logger = logging.getLogger(__name__)

--- a/cfdm/mixin/propertiesdata.py
+++ b/cfdm/mixin/propertiesdata.py
@@ -1,17 +1,11 @@
 import logging
 
 from ..data import Data
-
+from ..decorators import (_display_or_return, _inplace_enabled,
+                          _inplace_enabled_define_and_cleanup,
+                          _manage_log_level_via_verbosity,
+                          _test_decorator_args)
 from . import Properties
-
-from ..decorators import (
-    _display_or_return,
-    _inplace_enabled,
-    _inplace_enabled_define_and_cleanup,
-    _manage_log_level_via_verbosity,
-    _test_decorator_args,
-)
-
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/mixin/propertiesdatabounds.py
+++ b/cfdm/mixin/propertiesdatabounds.py
@@ -2,9 +2,12 @@ import logging
 from functools import reduce
 from operator import mul
 
-from ..decorators import (_display_or_return, _inplace_enabled,
-                          _inplace_enabled_define_and_cleanup,
-                          _manage_log_level_via_verbosity)
+from ..decorators import (
+    _display_or_return,
+    _inplace_enabled,
+    _inplace_enabled_define_and_cleanup,
+    _manage_log_level_via_verbosity,
+)
 from . import PropertiesData
 
 logger = logging.getLogger(__name__)

--- a/cfdm/mixin/propertiesdatabounds.py
+++ b/cfdm/mixin/propertiesdatabounds.py
@@ -1,17 +1,11 @@
 import logging
-
 from functools import reduce
 from operator import mul
 
+from ..decorators import (_display_or_return, _inplace_enabled,
+                          _inplace_enabled_define_and_cleanup,
+                          _manage_log_level_via_verbosity)
 from . import PropertiesData
-
-from ..decorators import (
-    _display_or_return,
-    _inplace_enabled,
-    _inplace_enabled_define_and_cleanup,
-    _manage_log_level_via_verbosity,
-)
-
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/nodecountproperties.py
+++ b/cfdm/nodecountproperties.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class NodeCountProperties(

--- a/cfdm/partnodecountproperties.py
+++ b/cfdm/partnodecountproperties.py
@@ -1,5 +1,4 @@
-from . import mixin
-from . import core
+from . import core, mixin
 
 
 class PartNodeCountProperties(

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -5,24 +5,19 @@ import re
 import struct
 import subprocess
 import tempfile
-
 from ast import literal_eval
 from collections import OrderedDict
 from copy import deepcopy
 from distutils.version import LooseVersion
 from functools import reduce
 
-import numpy
 import netCDF4
-
 import netcdf_flattener
+import numpy
 
 from ...decorators import _manage_log_level_via_verbosity
-
 from ...functions import is_log_level_debug
-
 from .. import IORead
-
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -2,18 +2,14 @@ import copy
 import logging
 import os
 import re
-
 from distutils.version import LooseVersion
 
-import numpy
 import netCDF4
-
-from .. import IOWrite
-
-from .netcdfread import NetCDFRead
+import numpy
 
 from ...decorators import _manage_log_level_via_verbosity
-
+from .. import IOWrite
+from .netcdfread import NetCDFRead
 
 logger = logging.getLogger(__name__)
 

--- a/cfdm/read_write/read.py
+++ b/cfdm/read_write/read.py
@@ -3,9 +3,7 @@ import os
 from numpy.ma.core import MaskError
 
 from ..cfdmimplementation import implementation
-
 from .netcdf import NetCDFRead
-
 
 _implementation = implementation()
 

--- a/cfdm/read_write/write.py
+++ b/cfdm/read_write/write.py
@@ -1,7 +1,5 @@
 from ..cfdmimplementation import implementation
-
 from .netcdf import NetCDFWrite
-
 
 _implementation = implementation()
 

--- a/cfdm/test/create_test_files.py
+++ b/cfdm/test/create_test_files.py
@@ -1,17 +1,15 @@
 import datetime
+import faulthandler
 import os
 import unittest
 
 import numpy
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import netCDF4
 
 import cfdm
-
 
 VN = cfdm.CF()
 

--- a/cfdm/test/run_tests.py
+++ b/cfdm/test/run_tests.py
@@ -1,14 +1,12 @@
 import datetime
 import doctest
+import faulthandler
 import importlib
 import os
 import pkgutil
 import unittest
-
 from argparse import ArgumentParser
 from random import choice, shuffle
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/setup_create_field.py
+++ b/cfdm/test/setup_create_field.py
@@ -1,15 +1,13 @@
 import datetime
+import faulthandler
 import os
 import unittest
 
 import numpy
 
-import faulthandler
-
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
 
 verbose = False
 warnings = False

--- a/cfdm/test/setup_create_field_2.py
+++ b/cfdm/test/setup_create_field_2.py
@@ -1,10 +1,9 @@
 import datetime
+import faulthandler
 import os
 import unittest
 
 import numpy
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/setup_create_field_3.py
+++ b/cfdm/test/setup_create_field_3.py
@@ -1,15 +1,13 @@
 import datetime
+import faulthandler
 import os
 import unittest
 
 import numpy
 
-import faulthandler
-
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
 
 verbose = False
 warnings = False

--- a/cfdm/test/test_AuxiliaryCoordinate.py
+++ b/cfdm/test/test_AuxiliaryCoordinate.py
@@ -1,10 +1,9 @@
 import datetime
+import faulthandler
 import os
 import unittest
 
 import numpy
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_CFDMImplementation.py
+++ b/cfdm/test/test_CFDMImplementation.py
@@ -1,7 +1,6 @@
 import datetime
-import unittest
-
 import faulthandler
+import unittest
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_CellMeasure.py
+++ b/cfdm/test/test_CellMeasure.py
@@ -1,8 +1,7 @@
 import datetime
+import faulthandler
 import os
 import unittest
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_CellMethod.py
+++ b/cfdm/test/test_CellMethod.py
@@ -1,8 +1,7 @@
 import datetime
+import faulthandler
 import os
 import unittest
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_Constructs.py
+++ b/cfdm/test/test_Constructs.py
@@ -1,9 +1,8 @@
 import copy
 import datetime
+import faulthandler
 import re
 import unittest
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_CoordinateReference.py
+++ b/cfdm/test/test_CoordinateReference.py
@@ -1,15 +1,13 @@
 import atexit
 import datetime
+import faulthandler
 import os
 import tempfile
 import unittest
 
-import faulthandler
-
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
 
 n_tmpfiles = 1
 tmpfiles = [

--- a/cfdm/test/test_Count.py
+++ b/cfdm/test/test_Count.py
@@ -1,7 +1,6 @@
 import datetime
-import unittest
-
 import faulthandler
+import unittest
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_Data.py
+++ b/cfdm/test/test_Data.py
@@ -1,12 +1,11 @@
 import copy
 import datetime
+import faulthandler
 import itertools
 import os
 import unittest
 
 import numpy
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_DimensionCoordinate.py
+++ b/cfdm/test/test_DimensionCoordinate.py
@@ -1,10 +1,9 @@
 import datetime
+import faulthandler
 import os
 import unittest
 
 import numpy
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_Domain.py
+++ b/cfdm/test/test_Domain.py
@@ -1,8 +1,7 @@
 import datetime
+import faulthandler
 import os
 import unittest
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_DomainAncillary.py
+++ b/cfdm/test/test_DomainAncillary.py
@@ -1,10 +1,9 @@
 import datetime
+import faulthandler
 import os
 import unittest
 
 import numpy
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_DomainAxis.py
+++ b/cfdm/test/test_DomainAxis.py
@@ -1,7 +1,6 @@
 import datetime
-import unittest
-
 import faulthandler
+import unittest
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_Field.py
+++ b/cfdm/test/test_Field.py
@@ -1,6 +1,7 @@
 import atexit
 import collections
 import datetime
+import faulthandler
 import os
 import re
 import tempfile
@@ -8,12 +9,9 @@ import unittest
 
 import numpy
 
-import faulthandler
-
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
 
 n_tmpfiles = 1
 tmpfiles = [

--- a/cfdm/test/test_FieldAncillary.py
+++ b/cfdm/test/test_FieldAncillary.py
@@ -1,8 +1,7 @@
 import datetime
+import faulthandler
 import os
 import unittest
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_Index.py
+++ b/cfdm/test/test_Index.py
@@ -1,7 +1,6 @@
 import datetime
-import unittest
-
 import faulthandler
+import unittest
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_InteriorRing.py
+++ b/cfdm/test/test_InteriorRing.py
@@ -1,8 +1,7 @@
 import datetime
+import faulthandler
 import os
 import unittest
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_List.py
+++ b/cfdm/test/test_List.py
@@ -1,7 +1,6 @@
 import datetime
-import unittest
-
 import faulthandler
+import unittest
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_NodeCountProperties.py
+++ b/cfdm/test/test_NodeCountProperties.py
@@ -1,8 +1,7 @@
 import datetime
+import faulthandler
 import os
 import unittest
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_NumpyArray.py
+++ b/cfdm/test/test_NumpyArray.py
@@ -1,9 +1,9 @@
-import datetime
 import copy
-import numpy
+import datetime
+import faulthandler
 import unittest
 
-import faulthandler
+import numpy
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_PartNodeCountProperties.py
+++ b/cfdm/test/test_PartNodeCountProperties.py
@@ -1,8 +1,7 @@
 import datetime
+import faulthandler
 import os
 import unittest
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_RaggedContiguousArray.py
+++ b/cfdm/test/test_RaggedContiguousArray.py
@@ -1,7 +1,6 @@
 import datetime
-import unittest
-
 import faulthandler
+import unittest
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_RaggedIndexedArray.py
+++ b/cfdm/test/test_RaggedIndexedArray.py
@@ -1,7 +1,6 @@
 import datetime
-import unittest
-
 import faulthandler
+import unittest
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_RaggedIndexedContiguousArray.py
+++ b/cfdm/test/test_RaggedIndexedContiguousArray.py
@@ -1,7 +1,6 @@
 import datetime
-import unittest
-
 import faulthandler
+import unittest
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_core_1.py
+++ b/cfdm/test/test_core_1.py
@@ -1,9 +1,8 @@
 import datetime
+import faulthandler
 import unittest
 
 import numpy
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_decorators.py
+++ b/cfdm/test/test_decorators.py
@@ -1,15 +1,13 @@
 import copy
 import datetime
+import faulthandler
 import itertools
 import unittest
 from unittest.mock import patch
 
-import faulthandler
-
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
 
 # Note: it is important we test on the cfdm logging config rather than the
 # generic Python module logging (i.e. 'cfdm.logging' not just 'logging').

--- a/cfdm/test/test_docstring.py
+++ b/cfdm/test/test_docstring.py
@@ -1,8 +1,7 @@
 import datetime
+import faulthandler
 import inspect
 import unittest
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_dsg.py
+++ b/cfdm/test/test_dsg.py
@@ -1,17 +1,15 @@
 import atexit
 import datetime
+import faulthandler
 import os
 import tempfile
 import unittest
 
 import numpy
 
-import faulthandler
-
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
 
 n_tmpfiles = 1
 tmpfiles = [

--- a/cfdm/test/test_external.py
+++ b/cfdm/test/test_external.py
@@ -1,15 +1,13 @@
 import atexit
 import datetime
+import faulthandler
 import os
 import tempfile
 import unittest
 
-import faulthandler
-
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
 
 n_tmpfiles = 3
 tmpfiles = [

--- a/cfdm/test/test_functions.py
+++ b/cfdm/test/test_functions.py
@@ -1,6 +1,7 @@
 import atexit
 import copy
 import datetime
+import faulthandler
 import logging
 import os
 import platform
@@ -10,12 +11,9 @@ import unittest
 
 import numpy
 
-import faulthandler
-
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
 
 n_tmpfiles = 1
 tmpfiles = [

--- a/cfdm/test/test_gathering.py
+++ b/cfdm/test/test_gathering.py
@@ -1,17 +1,15 @@
 import atexit
 import datetime
+import faulthandler
 import os
 import tempfile
 import unittest
 
 import numpy
 
-import faulthandler
-
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
 
 n_tmpfiles = 1
 tmpfiles = [

--- a/cfdm/test/test_geometry.py
+++ b/cfdm/test/test_geometry.py
@@ -1,15 +1,13 @@
 import atexit
 import datetime
+import faulthandler
 import os
 import tempfile
 import unittest
 
-import faulthandler
-
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
 
 n_tmpfiles = 1
 tmpfiles = [

--- a/cfdm/test/test_groups.py
+++ b/cfdm/test/test_groups.py
@@ -1,17 +1,15 @@
 import atexit
 import datetime
+import faulthandler
 import os
 import tempfile
 import unittest
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import netCDF4
 
 import cfdm
-
 
 n_tmpfiles = 9
 tmpfiles = [

--- a/cfdm/test/test_netCDF.py
+++ b/cfdm/test/test_netCDF.py
@@ -1,15 +1,13 @@
 import atexit
 import datetime
+import faulthandler
 import os
 import tempfile
 import unittest
 
-import faulthandler
-
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
 
 n_tmpfiles = 3
 tmpfiles = [

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -1,5 +1,6 @@
 import atexit
 import datetime
+import faulthandler
 import os
 import platform
 import subprocess
@@ -7,8 +8,6 @@ import tempfile
 import unittest
 
 import numpy
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfdm/test/test_string.py
+++ b/cfdm/test/test_string.py
@@ -1,17 +1,15 @@
 import atexit
 import datetime
+import faulthandler
 import os
 import tempfile
 import unittest
 
 import numpy
 
-import faulthandler
-
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
-
 
 n_tmpfiles = 1
 tmpfiles = [

--- a/cfdm/test/test_style.py
+++ b/cfdm/test/test_style.py
@@ -1,9 +1,9 @@
 import datetime
+import faulthandler
 import os
-import pycodestyle
 import unittest
 
-import faulthandler
+import pycodestyle
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,12 +13,11 @@
 # out serve to show the default.
 
 import datetime
-import sys
+import inspect
 import os
 import re
-import inspect
-
-from os.path import relpath, dirname
+import sys
+from os.path import dirname, relpath
 
 import cfdm
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,7 @@
 # the 'black' documentation.
 [tool.black]
 line-length = 79
+
+# Set for compatibility of 'black' and 'isort' auto-formatting tools
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ line-length = 79
 # Set for compatibility of 'black' and 'isort' auto-formatting tools
 [tool.isort]
 profile = "black"
+# ... and since we set this against the black default line length:
+line_length=79
 # Prevent isort from auto-formatting '__init__.py' file imports because
 # they require a specific non-aphabetical (etc.) ordering else they will
 # cause errors due to bad or circular importing across the modules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,9 @@ line-length = 79
 # Set for compatibility of 'black' and 'isort' auto-formatting tools
 [tool.isort]
 profile = "black"
+# Prevent isort from auto-formatting '__init__.py' file imports because
+# they require a specific non-aphabetical (etc.) ordering else they will
+# cause errors due to bad or circular importing across the modules.
+extend_skip_glob = [
+  "**/__init__.py",
+]

--- a/scripts/cfdump
+++ b/scripts/cfdump
@@ -6,6 +6,7 @@ if __name__ == "__main__":
     import getopt
     import os
     import sys
+
     import cfdm
 
     def print_help(version, date):

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
+import fnmatch
+import os
+import re
+
 from setuptools import setup
 
 # from setuptools import setup
-
-import os
-import fnmatch
-import re
 
 
 def find_package_data_files(directory):


### PR DESCRIPTION
As per title description. No functional changes made, just automatic re-organisation of import statments. See NCAS-CMS/cf-python#63 for context: I am adding PRs now to apply `isort` across cfunits, cfdm and cf-python in turn.