### PR TITLE
Prevent seg. fault in `cfdm.write` append mode test

### DIFF
--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -293,9 +293,6 @@ class read_writeTest(unittest.TestCase):
             # Note: can remove this del when Issue #140 is closed:
             if fmt in self.netcdf3_fmts:
                 del append_ex_fields[5]  # n=6 ex_field, minus 1 for above del
-            if fmt in "NETCDF4_CLASSIC":
-                # Remove n=5, 6, 7 for reasons as given above (del => minus 1)
-                append_ex_fields = append_ex_fields[:4]
 
             overall_length = len(append_ex_fields) + 1  # 1 for original 'g'
             cfdm.write(


### PR DESCRIPTION
Close #155 by avoiding the underlying issue of Unidata/netcdf4-python#261 in the test only where necessary (for the test over the `fmt="NETCDF4"`, by deleting the construct with the VLEN array).

Additionally, remove a dud test skip (due to a bad use of the keyword `in` it wasn't ever being run, so it can't have been necessary!)
