### PR TITLE
Fix `cfdm.write` failure for a vertical CRS that has no coordinates

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,8 +3,8 @@ Version 1.9.?.?
 
 **2021-??-??**
 
-* Fixed bug that caused `cfdm.write` failure for some fields with a
-  vertical coordinate reference system
+* Fixed bug that caused a `cfdm.write` failure when a vertical
+  coordinate reference construct has no coordinates
   (https://github.com/NCAS-CMS/cfdm/issues/164)
 
 ----

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,14 @@
+Version 1.9.?.?
+---------------
+
+**2021-??-??**
+
+* Fixed bug that caused `cfdm.write` failure for some fields with a
+  vertical coordinate reference system
+  (https://github.com/NCAS-CMS/cfdm/issues/164)
+
+----
+  
 Version 1.9.0.1
 ---------------
 

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -3721,10 +3721,9 @@ class NetCDFWrite(IOWrite):
 
                 if len(c) == 1:
                     owning_coord_key, _ = c[0]
-
-            z_axis = self.implementation.get_construct_data_axes(
-                f, owning_coord_key
-            )[0]
+                    z_axis = self.implementation.get_construct_data_axes(
+                        f, owning_coord_key
+                    )[0]
 
             if owning_coord_key is not None:
                 # This formula_terms coordinate reference matches up

--- a/cfdm/test/test_CoordinateReference.py
+++ b/cfdm/test/test_CoordinateReference.py
@@ -226,6 +226,14 @@ class CoordinateReferenceTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             cfdm.write(f, tempfile1)
 
+    def test_CoordinateReference_write(self):
+        """Test write when vertical CRS has no coordinates."""
+        f = cfdm.example_field(1)
+        c = f.construct("standard_name:atmosphere_hybrid_height_coordinate")
+        c.clear_coordinates()
+        # This write should not fail ...
+        cfdm.write(f, tempfile1)
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())


### PR DESCRIPTION
Fixes #164 