### PR TITLE
Add inspection testing covering any construct lacking data

### DIFF
--- a/cfdm/test/test_Domain.py
+++ b/cfdm/test/test_Domain.py
@@ -29,9 +29,6 @@ class DomainTest(unittest.TestCase):
     def test_Domain__repr__str__dump(self):
         """Test all means of Domain inspection."""
         d = self.d
-        f = self.f
-
-        t = f.construct("air_temperature standard_error")
 
         repr(d)
         str(d)
@@ -45,28 +42,19 @@ class DomainTest(unittest.TestCase):
         for title in (None, "title"):
             d.dump(display=False, _title=title)
 
+        # Test when any construct which can have data in fact has no data.
         d = d.copy()
-
-        # Test when all constructs which can have data in fact have no data.
-        t = d.construct("time")  # a dimension coordinate
-        t.del_data()
-        self.assertFalse(t.has_data())
-        str(d)
-
-        t = d.construct("latitude")  # an auxiliary coordinate
-        t.del_data()
-        self.assertFalse(t.has_data())
-        str(d)
-
-        t = d.construct("measure:area")  # a cell measure
-        t.del_data()
-        self.assertFalse(t.has_data())
-        str(d)
-
-        t = d.construct("surface_altitude")  # a domain ancillary
-        t.del_data()
-        self.assertFalse(t.has_data())
-        str(d)
+        for identity in [
+            "time",  # a dimension coordinate
+            "latitude",  # an auxiliary coordinate
+            "measure:area",  # a cell measure
+            "surface_altitude",  # a domain ancillary
+        ]:
+            c = d.construct(identity)  # get relevant construct, type as above
+            c.del_data()
+            self.assertFalse(c.has_data())
+            str(d)
+            repr(d)
 
     def test_Domain__init__(self):
         """Test the Domain constructor and source keyword."""

--- a/cfdm/test/test_Domain.py
+++ b/cfdm/test/test_Domain.py
@@ -29,6 +29,9 @@ class DomainTest(unittest.TestCase):
     def test_Domain__repr__str__dump(self):
         """Test all means of Domain inspection."""
         d = self.d
+        f = self.f
+
+        t = f.construct("air_temperature standard_error")
 
         repr(d)
         str(d)
@@ -42,9 +45,25 @@ class DomainTest(unittest.TestCase):
         for title in (None, "title"):
             d.dump(display=False, _title=title)
 
-        # Test when dimension coordinate has no data
         d = d.copy()
-        t = d.construct("time")
+
+        # Test when all constructs which can have data in fact have no data.
+        t = d.construct("time")  # a dimension coordinate
+        t.del_data()
+        self.assertFalse(t.has_data())
+        str(d)
+
+        t = d.construct("latitude")  # an auxiliary coordinate
+        t.del_data()
+        self.assertFalse(t.has_data())
+        str(d)
+
+        t = d.construct("measure:area")  # a cell measure
+        t.del_data()
+        self.assertFalse(t.has_data())
+        str(d)
+
+        t = d.construct("surface_altitude")  # a domain ancillary
         t.del_data()
         self.assertFalse(t.has_data())
         str(d)

--- a/cfdm/test/test_Field.py
+++ b/cfdm/test/test_Field.py
@@ -60,6 +60,21 @@ class FieldTest(unittest.TestCase):
         self.assertIsInstance(f.dump(display=False), str)
         self.assertEqual(f.construct_type, "field")
 
+        # Test when any construct which can have data in fact has no data.
+        f = f.copy()
+        for identity in [
+            "time",  # a dimension coordinate
+            "latitude",  # an auxiliary coordinate
+            "measure:area",  # a cell measure
+            "surface_altitude",  # a domain ancillary,
+            "air_temperature standard_error",  # a field ancillary
+        ]:
+            c = f.construct(identity)  # get relevant construct, type as above
+            c.del_data()
+            self.assertFalse(c.has_data())
+            str(f)
+            repr(f)
+
     def test_Field__init__(self):
         """Test the Field constructor and source keyword."""
         cfdm.Field(source="qwerty")


### PR DESCRIPTION
Follow-on PR to #175 to add some extra testing covering all other constructs that weren't buggy but it would regardless be good to check in a similar way, namely to call `str()` and `repr()` on where the constructs have no data, for any which can take data, so excluding only cell methods and coordinate references from the data model.

@davidhassell shall I also add equivalent tests to cf-python, or is that overkill?