### PR TITLE
Fix cfdm.write when writing identical (auxiliary) coordinates to data variables in different groups

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -5,7 +5,7 @@ Version 1.9.0.3
 
 * Fixed bug that caused a failure from `cfdm.write` when writing
   identical (auxiliary) coordinates to different data variables in
-  different groups (https://github.com/NCAS-CMS/cfdm/issues/175)
+  different groups (https://github.com/NCAS-CMS/cfdm/issues/177)
 * Fixed bug that caused `cf.Domain.__str__` to fail when a dimension
   coordinate construct does not have data
   (https://github.com/NCAS-CMS/cfdm/issues/174)

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,8 +1,11 @@
-Version 1.9.?.?
+Version 1.9.0.3
 ---------------
 
-**2022-0?-??**
+**2022-03-??**
 
+* Fixed bug that caused a failure from `cfdm.write` when writing
+  identical (auxiliary) coordinates to different data variables in
+  different groups (https://github.com/NCAS-CMS/cfdm/issues/175)
 * Fixed bug that caused `cf.Domain.__str__` to fail when a dimension
   coordinate construct does not have data
   (https://github.com/NCAS-CMS/cfdm/issues/174)

--- a/cfdm/core/__init__.py
+++ b/cfdm/core/__init__.py
@@ -1,8 +1,8 @@
 """"""
 
-__date__ = "2022-01-31"
+__date__ = "2022-03-??"
 __cf_version__ = "1.9"
-__version__ = "1.9.0.2"
+__version__ = "1.9.0.3"
 
 from distutils.version import LooseVersion
 import platform

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -2685,8 +2685,8 @@ class NetCDFWrite(IOWrite):
             )  # pragma: no cover
 
         # ------------------------------------------------------------
-        # Check that each dimension of the netCDF variable name is in
-        # the same group or else in a sub-group (CF>=1.8)
+        # Check that each dimension of the netCDF variable is in the
+        # same group or a parent group (CF>=1.8)
         # ------------------------------------------------------------
         if g["group"]:
             groups = self._groups(ncvar)
@@ -2695,8 +2695,8 @@ class NetCDFWrite(IOWrite):
                 if not groups.startswith(ncdim_groups):
                     raise ValueError(
                         f"Can't create netCDF variable {ncvar!r} from "
-                        f"{cfvar!r} with dimension {ncdim!r} that is not in "
-                        "the same group or a sub-group as the variable."
+                        f"{cfvar!r} with netCDF dimension {ncdim!r} that is "
+                        "not in the same group nor in a parent group."
                     )
 
         # ------------------------------------------------------------

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -327,23 +327,7 @@ class NetCDFWrite(IOWrite):
 
         array = numpy.array(tuple(array.tobytes().decode("ascii")), dtype="S1")
 
-        #        else:
-        #            # dtype is 'U'
-        #            x = []
-        #            for s in array.flatten():
-        #                x.extend(tuple(s.ljust(N, '\x00')))
-        #
-        #            array = numpy.array(k, dtype='S1')
-
         array.resize(original_shape + (array.size // original_size,))
-        #        if masked:
-        #            array = numpy.ma.array(array, mask=mask, fill_value=fill_value)
-
-        #        if array.dtype.kind == 'U':
-        #            # Convert unicode to string
-        #            array = array.astype('S')
-        #
-        #        new = netCDF4.stringtochar(array, encoding='none')
 
         if masked:
             array = numpy.ma.masked_where(array == "", array)
@@ -351,17 +335,6 @@ class NetCDFWrite(IOWrite):
 
         if array.dtype.kind != "S":
             raise ValueError("Array must have string data type.")
-
-        #            new = numpy.ma.array(new, mask=mask, fill_value=fill_value)
-
-        #        new = numpy.ma.masked_all(shape + (strlen,), dtype='S1')
-        #
-        #        for index in numpy.ndindex(shape):
-        #            value = array[index]
-        #            if value is numpy.ma.masked:
-        #                new[index] = numpy.ma.masked
-        #            else:
-        #                new[index] = tuple(value.ljust(strlen, ' '))
 
         return array
 
@@ -669,7 +642,7 @@ class NetCDFWrite(IOWrite):
             coordinates: `list`
                This list may get updated in-place.
 
-               .. versionadded:: (cfdm) .8.7.0
+               .. versionadded:: (cfdm) 1.8.7.0
 
         :Returns:
 
@@ -967,11 +940,7 @@ class NetCDFWrite(IOWrite):
             geometry_dimension = g["key_to_ncdims"][key][0]
 
             geometry_id = (geometry_dimension, geometry_type)
-            gc.setdefault(
-                geometry_id,
-                {"geometry_type": geometry_type}
-                #                 'geometry_dimension': geometry_dimension,
-            )
+            gc.setdefault(geometry_id, {"geometry_type": geometry_type})
 
             # Nodes
             nodes_ncvar = g["seen"][id(nodes)]["ncvar"]
@@ -1360,17 +1329,6 @@ class NetCDFWrite(IOWrite):
             coord_groups = self._groups(coord_ncvar)
             if not bounds_groups and coord_groups:
                 ncvar = coord_groups + ncvar
-
-            #            for ncdim in ncdimensions:
-            #                _, ncdim_groups = self._remove_group_structure(
-            #                    ncdim,
-            #                    return_groups=True)
-            #                if not bounds_groups.startswith(ncdim_groups):
-            #                    raise ValueError(
-            #                        "Can't find create a netCDF variable from {!r} "
-            #                        "with a dimension that is not in the same group or "
-            #                        "a sub-group as the variable: {}".format(bounds, ncdim)
-            #                    )
 
             # Note that, in a field, bounds always have equal units to
             # their parent coordinate
@@ -1868,9 +1826,6 @@ class NetCDFWrite(IOWrite):
         {}
 
         """
-        #        if self.implementation.get_data_ndim(bounds) < 3: # DCH
-        #            # No need for a part node count variable required
-        #            return {}
         if self.implementation.get_data_shape(bounds)[1] == 1:
             # No part node count variable required
             return {}
@@ -3349,18 +3304,6 @@ class NetCDFWrite(IOWrite):
                             f, position=0, axis=axis
                         )
                         data_axes.append(axis)
-
-                #                spanning_constructs = self.implementation.get_constructs(
-                #                    f, axes=[axis])
-                #
-                #                if axis not in data_axes and spanning_constructs:
-                #                    # The data array doesn't span the domain axis but
-                #                    # an auxiliary coordinate, cell measure, domain
-                #                    # ancillary or field ancillary does, so expand the
-                #                    # data array to include it.
-                #                    f = self.implementation.field_insert_dimension(
-                #                            f, position=0, axis=axis)
-                #                    data_axes.append(axis)
 
                 # If the data array (now) spans this domain axis then
                 # create a netCDF dimension for it
@@ -5020,14 +4963,6 @@ class NetCDFWrite(IOWrite):
         g["filename"] = filename
         g["netcdf"] = self.file_open(filename, mode, fmt, fields)
 
-        #        # -----------------------------------------------------------
-        #        # Set the fill mode for a Dataset open for writing to
-        #        off. This # will prevent the data from being pre-filled with
-        #        fill values, # which may result in some performance
-        #        improvements.  #
-        #        -------------------------------------------------------------
-        #        g['netcdf'].set_fill_off()
-
         if not g["dry_run"]:
             # ------------------------------------------------------------
             # Write global properties to the file first. This is important
@@ -5132,7 +5067,7 @@ class NetCDFWrite(IOWrite):
         """Return True if the netCDF dimension is in a valid group.
 
         Returns True if the dimension is in the same group, or a
-        parent group, as that defined by the construct. Otherwise
+        parent group, as the group defined by the construct. Otherwise
         return False.
 
         .. versionadded:: (cfdm) 1.9.0.3

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -697,12 +697,12 @@ class NetCDFWrite(IOWrite):
                 # coordinate.
                 create = True
 
-        # If the dimension coordinate is already in the file, but not
-        # in an approriate group, then make a new new netCDF variable.
-        #
-        # This is to prevent a downstream error ocurring when the
-        # parrent data variable tries to reference one of its netCDF
-        # dimensions that is not in the same group nor a parent group.
+        # If the dimension coordinate is already in the file but not
+        # in an approriate group then we have to create a new netCDF
+        # variable. This is to prevent a downstream error ocurring
+        # when the parent data variable tries to reference one of its
+        # netCDF dimensions that is not in the same group nor a parent
+        # group.
         if already_in_file and not create:
             ncvar = coord.nc_get_variable("")
             groups = self._groups(seen[id(coord)]["ncvar"])

--- a/cfdm/test/test_groups.py
+++ b/cfdm/test/test_groups.py
@@ -512,7 +512,6 @@ class GroupsTest(unittest.TestCase):
             file_content.append(f)
 
         # This should not raise an exception
-        grouped_file6 = "~/tmp/delme.nc"
         cfdm.write(file_content, grouped_file6)
 
 

--- a/cfdm/test/test_groups.py
+++ b/cfdm/test/test_groups.py
@@ -8,10 +8,11 @@ import unittest
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import netCDF4
+import numpy as np
 
 import cfdm
 
-n_tmpfiles = 9
+n_tmpfiles = 10
 tmpfiles = [
     tempfile.mkstemp("_test_groups.nc", dir=os.getcwd())[1]
     for i in range(n_tmpfiles)
@@ -26,6 +27,7 @@ tmpfiles = [
     grouped_file3,
     grouped_file4,
     grouped_file5,
+    grouped_file6,
 ) = tmpfiles
 
 
@@ -452,6 +454,64 @@ class GroupsTest(unittest.TestCase):
         self.assertEqual(len(h), 1)
         h = h[0]
         self.assertTrue(f.equals(h, verbose=3))
+
+    def test_groups_dimension_coordinates(self):
+        """TODO."""
+        time_data = list(range(5))
+        station_data = ["station1", "station2"]
+
+        file_content = list()
+        for mt in ("Dew Point", "Wind Speed"):
+            grp_name = mt.replace(" ", "_")
+            var_name = mt.replace(" ", "_")
+
+            stations = cfdm.DomainAxis(2)
+            stations.nc_set_dimension("stations")
+            stations.nc_set_dimension_groups([grp_name])
+
+            time = cfdm.DomainAxis(len(time_data))
+            time.nc_set_dimension("time")
+            time.nc_set_dimension_groups([grp_name])
+
+            station_name = cfdm.AuxiliaryCoordinate()
+            station_name.set_data(station_data)
+            station_name.set_properties(
+                {"long_name": "sensor id", "cf_role": "timeseries_id"}
+            )
+            station_name.nc_set_variable("station_name")
+            station_name.nc_set_variable_groups([grp_name])
+
+            times = cfdm.DimensionCoordinate()
+            times.set_data(time_data)
+            times.set_properties(
+                {"standard_name": "time", "units": "days since 1967-04-01"}
+            )
+            times.nc_set_variable("time")
+            times.nc_set_variable_groups([grp_name])
+
+            # Random data...
+            obs = np.random.uniform(
+                -10, 25, size=(time.get_size(), stations.get_size())
+            )
+
+            f = cfdm.Field()
+
+            station_axis = f.set_construct(stations)
+            time_axis = f.set_construct(time)
+
+            f.set_construct(times, axes=time_axis)
+            f.set_construct(station_name, axes=station_axis)
+
+            f.set_data(obs, axes=[time_axis, station_axis])
+
+            f.nc_set_variable(var_name)
+            f.nc_set_variable_groups([grp_name])
+
+            file_content.append(f)
+
+        # This should not raise an exception
+        grouped_file6 = "delme.nc"
+        cfdm.write(file_content, grouped_file6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #177 