### PR TITLE
Batch docstring formatting update: 'Examples:' -> 'Examples'

### DIFF
--- a/cfdm/abstract/implementation.py
+++ b/cfdm/abstract/implementation.py
@@ -27,7 +27,7 @@ class Implementation(metaclass=abc.ABCMeta):
             `dict`
                 The class objects, keyed by their class name.
 
-        **Examples:**
+        **Examples**
 
         >>> i = cfdm.Implementation()  # an abstract implementation
         >>> i.classes()
@@ -83,7 +83,7 @@ class Implementation(metaclass=abc.ABCMeta):
 
                 The class object.
 
-        **Examples:**
+        **Examples**
 
         >>> i = cfdm.implementation()  # child CF data model implementation
         >>> Field = i.get_class('Field')
@@ -103,7 +103,7 @@ class Implementation(metaclass=abc.ABCMeta):
             `str`
                 The version.
 
-        **Examples:**
+        **Examples**
 
         >>> i = cfdm.implementation()  # child CF data model implementation
         >>> i.get_cf_version()
@@ -130,7 +130,7 @@ class Implementation(metaclass=abc.ABCMeta):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> i = cfdm.Implementation()  # child CF data model implementation
         >>> i.classes()

--- a/cfdm/bounds.py
+++ b/cfdm/bounds.py
@@ -162,7 +162,7 @@ class Bounds(
             `Data`
                 The data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.Field(
         ...     properties={'standard_name': 'surface_altitude'})
@@ -229,7 +229,7 @@ class Bounds(
             `dict`
                 The inherited properties.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(6)
         >>> d = f.constructs('longitude').value()
@@ -270,7 +270,7 @@ class Bounds(
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(6)
         >>> d = f.constructs('longitude').value()

--- a/cfdm/cellmeasure.py
+++ b/cfdm/cellmeasure.py
@@ -130,7 +130,7 @@ class CellMeasure(
 
             {{returns creation_commands}}
 
-        **Examples:**
+        **Examples**
 
         >>> x = {{package}}.CellMeasure(
         ...     measure='area',
@@ -285,7 +285,7 @@ class CellMeasure(
             `bool`
                 Whether the two cell measure constructs are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.CellMeasure()
         >>> c.set_properties({'units': 'm2'})
@@ -355,7 +355,7 @@ class CellMeasure(
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(1)
         >>> c = f.get_construct('cellmeasure0')
@@ -434,7 +434,7 @@ class CellMeasure(
             `list` or generator
                 The identities.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(1)
         >>> c = f.get_construct('cellmeasure0')

--- a/cfdm/cellmethod.py
+++ b/cfdm/cellmethod.py
@@ -126,7 +126,7 @@ class CellMethod(mixin.Container, core.CellMethod):
 
             {{returns creation_commands}}
 
-        **Examples:**
+        **Examples**
 
         >>> x = {{package}}.CellMethod(
         ...     axes=['area'],
@@ -271,7 +271,7 @@ class CellMethod(mixin.Container, core.CellMethod):
             `bool`
                 Whether the two cell method constructs are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.CellMethod()
         >>> c.equals(c)
@@ -408,7 +408,7 @@ class CellMethod(mixin.Container, core.CellMethod):
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(1)
         >>> c = f.get_construct('cellmethod1')
@@ -460,7 +460,7 @@ class CellMethod(mixin.Container, core.CellMethod):
             `list` or generator
                 The identities.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(1)
         >>> c = f.get_construct('cellmethod1')
@@ -503,7 +503,7 @@ class CellMethod(mixin.Container, core.CellMethod):
             `CellMethod`
                 A new cell method construct with sorted axes.
 
-        **Examples:**
+        **Examples**
 
         >>> cm = {{package}}.CellMethod(axes=['domainaxis1', 'domainaxis0'],
         ...                      method='mean',

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -887,7 +887,7 @@ class CFDMImplementation(Implementation):
             `int`
                 The number of dimensions spanned by the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> w = cfdm.implementation()
         >>> d = cfdm.DimensionCoordinate(
@@ -929,7 +929,7 @@ class CFDMImplementation(Implementation):
             `tuple`
                 The shape of the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> w = cfdm.implementation()
         >>> d = cfdm.DimensionCoordinate(
@@ -971,7 +971,7 @@ class CFDMImplementation(Implementation):
             `int`
                 The number of elements in the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> w = cfdm.implementation()
         >>> d = cfdm.DimensionCoordinate(
@@ -1413,7 +1413,7 @@ class CFDMImplementation(Implementation):
                 A dictionary whose values are field ancillary objects, keyed
                 by unique identifiers.
 
-        **Examples:**
+        **Examples**
 
         >>> w = cfdm.implementation()
         >>> f = cfdm.example_field(1)
@@ -1610,7 +1610,7 @@ class CFDMImplementation(Implementation):
             `str` or `None`
                 The measure property, or `None` if it has not been set.
 
-        **Examples:**
+        **Examples**
 
         >>> w = cfdm.implementation()
         >>> c = cfdm.CellMeasure(
@@ -1705,7 +1705,7 @@ class CFDMImplementation(Implementation):
             `dict`
                 The property names and their values
 
-        **Examples:**
+        **Examples**
 
         >>> w = cfdm.implementation()
         >>> d = cfdm.DimensionCoordinate(
@@ -1771,7 +1771,7 @@ class CFDMImplementation(Implementation):
 
                 The data.
 
-        **Examples:**
+        **Examples**
 
         >>> w = cfdm.implementation()
         >>> d = cfdm.DimensionCoordinate(
@@ -3277,7 +3277,7 @@ class CFDMImplementation(Implementation):
 
             `bool`
 
-        **Examples:**
+        **Examples**
 
         >>> w = cfdm.implementation()
 
@@ -3327,7 +3327,7 @@ class CFDMImplementation(Implementation):
             `bool`
                 `True` if the property exists, otherwise `False`.
 
-        **Examples:**
+        **Examples**
 
         >>> w = cfdm.implementation()
         >>> d = cfdm.DimensionCoordinate(
@@ -3415,7 +3415,7 @@ def implementation():
         `CFDMImplementation`
             A container for the CF data model implementation.
 
-    **Examples:**
+    **Examples**
 
     >>> i = cfdm.implementation()
     >>> i

--- a/cfdm/constructs.py
+++ b/cfdm/constructs.py
@@ -80,7 +80,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs`
                 The selected constructs and their construct keys.
 
-        **Examples:**
+        **Examples**
 
         See `filter_by_identity` and `filter` for examples.
 
@@ -161,7 +161,7 @@ class Constructs(mixin.Container, core.Constructs):
 
             `dict`
 
-        **Examples:**
+        **Examples**
 
         >>> f.constructs._axes_to_constructs()
         {('domainaxis0',): {'auxiliary_coordinate': {},
@@ -256,7 +256,7 @@ class Constructs(mixin.Container, core.Constructs):
 
                 The removed construct.
 
-        **Examples:**
+        **Examples**
 
         >>> x = c._del_construct('auxiliarycoordinate2')
 
@@ -646,7 +646,7 @@ class Constructs(mixin.Container, core.Constructs):
              `str`
                 The construct identifier for the construct.
 
-        **Examples:**
+        **Examples**
 
         >>> key = f._set_construct(c)
         >>> key = f._set_construct(c, copy=False)
@@ -967,7 +967,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs`
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f.copy()
         >>> g = f.copy(data=False)
@@ -1010,7 +1010,7 @@ class Constructs(mixin.Container, core.Constructs):
             `str`
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> c.domain_axis_identity('domainaxis1')
         'longitude'
@@ -1123,7 +1123,7 @@ class Constructs(mixin.Container, core.Constructs):
 
                 {{Returns constructs}}
 
-        **Examples:**
+        **Examples**
 
         """
         cached = filter_kwargs.get("cached")
@@ -1230,7 +1230,7 @@ class Constructs(mixin.Container, core.Constructs):
             `bool`
                 Whether the two instances are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> x.equals(x)
         True
@@ -1787,7 +1787,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs` or `dict` or *cached*
                 The selected constructs, or a cached valued.
 
-        **Examples:**
+        **Examples**
 
         Select constructs whose data spans the "domainaxis1" domain
         axis construct:
@@ -1864,7 +1864,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs` or `dict` or *cached*
                 The selected constructs, or a cached valued.
 
-        **Examples:**
+        **Examples**
 
         Select constructs that could contain data:
 
@@ -2040,7 +2040,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs` or `dict` or *cached*
                 The selected constructs, or a cached valued.
 
-        **Examples:**
+        **Examples**
 
         Select constructs that have a ``standard_name`` property of
         'latitude':
@@ -2130,7 +2130,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs` or `dict` or *cached*
                 The selected constructs, or a cached valued.
 
-        **Examples:**
+        **Examples**
 
         Select the construct with key 'domainancillary0':
 
@@ -2225,7 +2225,7 @@ class Constructs(mixin.Container, core.Constructs):
                 The selected cell measure constructs and their
                 construct keys.
 
-        **Examples:**
+        **Examples**
 
         >>> print(t.constructs.filter_by_type('measure'))
         Constructs:
@@ -2342,7 +2342,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs` or `dict` or *cached*
                 The selected constructs, or a cached valued.
 
-        **Examples:**
+        **Examples**
 
         >>> print(c.constructs.filter_by_type('cell_method'))
         Constructs:
@@ -2454,7 +2454,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs` or `dict` or *cached*
                 The selected constructs, or a cached valued.
 
-        **Examples:**
+        **Examples**
 
         Select constructs that contain data that spans two domain axis
         constructs:
@@ -2552,7 +2552,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs` or `dict` or *cached*
                 The selected constructs, or a cached valued.
 
-        **Examples:**
+        **Examples**
 
         Select the domain axis constructs with netCDF dimension name
         'time':
@@ -2650,7 +2650,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs` or `dict` or *cached*
                 The selected constructs, or a cached valued.
 
-        **Examples:**
+        **Examples**
 
         Select the constructs with netCDF variable name 'time':
 
@@ -2808,7 +2808,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs`
                 The selected constructs.
 
-        **Examples:**
+        **Examples**
 
         Select constructs that have a ``standard_name`` of 'latitude':
 
@@ -2903,7 +2903,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs` or `dict` or *cached*
                 The selected constructs, or a cached valued.
 
-        **Examples:**
+        **Examples**
 
         Select domain axis constructs that have a size of 1:
 
@@ -2992,7 +2992,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs` or `dict` or *cached*
                 The selected constructs, or a cached valued.
 
-        **Examples:**
+        **Examples**
 
         Select dimension coordinate constructs:
 
@@ -3030,7 +3030,7 @@ class Constructs(mixin.Container, core.Constructs):
                 from first to last. If no filters have been applied
                 then the tuple is empty.
 
-        **Examples:**
+        **Examples**
 
         >>> print(c)
         {'auxiliarycoordinate0': <{{repr}}AuxiliaryCoordinate: latitude(10, 9) degrees_N>,
@@ -3093,7 +3093,7 @@ class Constructs(mixin.Container, core.Constructs):
                 applied then the tuple is empty.
 
 
-        **Examples:**
+        **Examples**
 
         >>> c.filters_applied()
         ({'filter_by_naxes': (3, 1)},
@@ -3152,7 +3152,7 @@ class Constructs(mixin.Container, core.Constructs):
                 inverse filter, then an empty `Constructs` instance is
                 returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(c)
         Constructs:
@@ -3247,7 +3247,7 @@ class Constructs(mixin.Container, core.Constructs):
             `Constructs`
                 The shallow copy.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f.shallow_copy()
 
@@ -3298,7 +3298,7 @@ class Constructs(mixin.Container, core.Constructs):
                 before the last filter was applied. If no filters have
                 been applied then all of the constructs are returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(c)
         Constructs:

--- a/cfdm/coordinatereference.py
+++ b/cfdm/coordinatereference.py
@@ -193,7 +193,7 @@ class CoordinateReference(
 
             {{returns creation_commands}}
 
-        **Examples:**
+        **Examples**
 
         >>> x = {{package}}.{{class}}(
         ...     coordinates=['dimensioncoordinate0']
@@ -423,7 +423,7 @@ class CoordinateReference(
             `bool`
                 Whether the two coordinate reference constructs are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}(
         ...     coordinates=['dimensioncoordinate0']
@@ -509,7 +509,7 @@ class CoordinateReference(
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(1)
         >>> c = f.get_construct('coordinatereference0')
@@ -573,7 +573,7 @@ class CoordinateReference(
             `list` or generator
                 The identities.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(1)
         >>> c = f.get_construct('coordinatereference0')

--- a/cfdm/core/abstract/container.py
+++ b/cfdm/core/abstract/container.py
@@ -56,7 +56,7 @@ class Container(metaclass=DocstringRewriteMeta):
 
         .. versionadded:: (cfdm) 1.7.0
 
-        **Examples:**
+        **Examples**
 
         >>> import copy
         >>> f = {{package}}.{{class}}()
@@ -114,7 +114,7 @@ class Container(metaclass=DocstringRewriteMeta):
                 The value of *default* if it is not an `Exception`
                 instance.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f._default(AttributeError())  # Raises Exception
@@ -167,7 +167,7 @@ class Container(metaclass=DocstringRewriteMeta):
                 The removed component. If unset then *default* is
                 returned, if provided.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f._set_component('foo', 'bar')
@@ -201,7 +201,7 @@ class Container(metaclass=DocstringRewriteMeta):
 
         .. versionadded:: (cfdm) 1.7.4
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f._custom
@@ -244,7 +244,7 @@ class Container(metaclass=DocstringRewriteMeta):
                 The component. If unset then *default* is returned, if
                 provided.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f._set_component('foo', 'bar')
@@ -286,7 +286,7 @@ class Container(metaclass=DocstringRewriteMeta):
             `bool`
                 True if the component has been set, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f._set_component('foo', 'bar')
@@ -321,7 +321,7 @@ class Container(metaclass=DocstringRewriteMeta):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f._set_component('foo', 'bar')
@@ -355,7 +355,7 @@ class Container(metaclass=DocstringRewriteMeta):
             `{{class}}`
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> g = f.copy()

--- a/cfdm/core/abstract/coordinate.py
+++ b/cfdm/core/abstract/coordinate.py
@@ -29,7 +29,7 @@ class Coordinate(PropertiesDataBounds):
             `str`
                 The removed climatology value.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_climatology(True)
@@ -81,7 +81,7 @@ class Coordinate(PropertiesDataBounds):
 
             `str`
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_climatology(True)
@@ -126,7 +126,7 @@ class Coordinate(PropertiesDataBounds):
             `bool`
                 Whether or not the coordinates are climatological.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_climatology(True)
@@ -169,7 +169,7 @@ class Coordinate(PropertiesDataBounds):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_climatology(True)

--- a/cfdm/core/abstract/parameters.py
+++ b/cfdm/core/abstract/parameters.py
@@ -61,7 +61,7 @@ class Parameters(Container):
             `dict`
                 The parameters that have been removed.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.parameters()
@@ -110,7 +110,7 @@ class Parameters(Container):
 
                 The removed parameter value.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_parameter('earth_radius', 6371007)
@@ -159,7 +159,7 @@ class Parameters(Container):
 
                 The value of the parameter.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_parameter('earth_radius', 6371007)
@@ -209,7 +209,7 @@ class Parameters(Container):
              `bool`
                 True if the parameter has been set, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_parameter('earth_radius', 6371007)
@@ -242,7 +242,7 @@ class Parameters(Container):
             `dict`
                 The parameters.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.parameters()
@@ -290,7 +290,7 @@ class Parameters(Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.parameters()
@@ -328,7 +328,7 @@ class Parameters(Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_parameter('earth_radius', 6371007)

--- a/cfdm/core/abstract/parametersdomainancillaries.py
+++ b/cfdm/core/abstract/parametersdomainancillaries.py
@@ -76,7 +76,7 @@ class ParametersDomainAncillaries(Parameters):
             `dict`
                 The domain ancillaries that have been removed.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.domain_ancillaries()
@@ -130,7 +130,7 @@ class ParametersDomainAncillaries(Parameters):
             `str`
                 The removed domain ancillary key.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_domain_ancillary('orog', 'domainancillary2')
@@ -174,7 +174,7 @@ class ParametersDomainAncillaries(Parameters):
             `dict`
                 The domain ancillaries.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.domain_ancillaries()
@@ -222,7 +222,7 @@ class ParametersDomainAncillaries(Parameters):
 
                 The domain ancillary construct key.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_domain_ancillary('orog', 'domainancillary2')
@@ -268,7 +268,7 @@ class ParametersDomainAncillaries(Parameters):
 
                 The domain ancillary construct key.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_domain_ancillary('orog', 'domainancillary2')
@@ -313,7 +313,7 @@ class ParametersDomainAncillaries(Parameters):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.domain_ancillaries()
@@ -361,7 +361,7 @@ class ParametersDomainAncillaries(Parameters):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_domain_ancillary('orog', 'domainancillary2')

--- a/cfdm/core/abstract/properties.py
+++ b/cfdm/core/abstract/properties.py
@@ -55,7 +55,7 @@ class Properties(Container):
             `dict`
                 The properties that have been removed.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.properties()
@@ -108,7 +108,7 @@ class Properties(Container):
 
                 The removed property value.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_property('project', 'CMIP7')
@@ -163,7 +163,7 @@ class Properties(Container):
 
                 The value of the property.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_property('project', 'CMIP7')
@@ -205,7 +205,7 @@ class Properties(Container):
 
             `False`
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.has_bounds()
@@ -225,7 +225,7 @@ class Properties(Container):
 
             `False`
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.has_data()
@@ -255,7 +255,7 @@ class Properties(Container):
             `bool`
                 True if the property has been set, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_property('project', 'CMIP7')
@@ -288,7 +288,7 @@ class Properties(Container):
             `dict`
                 The properties.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.properties()
@@ -337,7 +337,7 @@ class Properties(Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.properties()
@@ -390,7 +390,7 @@ class Properties(Container):
 
              `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_property('project', 'CMIP7')

--- a/cfdm/core/abstract/propertiesdata.py
+++ b/cfdm/core/abstract/propertiesdata.py
@@ -93,7 +93,7 @@ class PropertiesData(Properties):
 
             `Data`
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_data([1, 2, 3])
@@ -134,7 +134,7 @@ class PropertiesData(Properties):
             `Data`
                 The data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_data({{package}}.Data(numpy.arange(10.)))
@@ -175,7 +175,7 @@ class PropertiesData(Properties):
             `{{class}}`
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f.copy()
         >>> g = f.copy(data=False)
@@ -205,7 +205,7 @@ class PropertiesData(Properties):
             `Data`
                 The removed data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_data([1, 2, 3])
@@ -260,7 +260,7 @@ class PropertiesData(Properties):
             `Data`
                 The data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_data([1, 2, 3])
@@ -333,7 +333,7 @@ class PropertiesData(Properties):
             `bool`
                 Always False.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.has_bounds()
@@ -354,7 +354,7 @@ class PropertiesData(Properties):
             `bool`
                 True if data have been set, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_data([1, 2, 3])
@@ -411,7 +411,7 @@ class PropertiesData(Properties):
                 otherwise return a new `{{class}}` instance containing the
                 new data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_data([1, 2, 3])

--- a/cfdm/core/abstract/propertiesdatabounds.py
+++ b/cfdm/core/abstract/propertiesdatabounds.py
@@ -115,7 +115,7 @@ class PropertiesDataBounds(PropertiesData):
             `Bounds`
                 The bounds.
 
-        **Examples:**
+        **Examples**
 
 
         >>> c = {{package}}.{{class}}()
@@ -150,7 +150,7 @@ class PropertiesDataBounds(PropertiesData):
             `InteriorRing`
                 The interior ring variable.
 
-        **Examples:**
+        **Examples**
 
 
         >>> i = {{package}}.InteriorRing(data={{package}}.Data(numpy.arange(10).reshape(5, 2)))
@@ -191,7 +191,7 @@ class PropertiesDataBounds(PropertiesData):
             `Bounds`
                 The removed bounds.
 
-        **Examples:**
+        **Examples**
 
 
         >>> c = {{package}}.{{class}}()
@@ -241,7 +241,7 @@ class PropertiesDataBounds(PropertiesData):
             `str`
                 The removed geometry type.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.read('file.nc')[0]
         >>> c = f.construct('axis=X')
@@ -291,7 +291,7 @@ class PropertiesDataBounds(PropertiesData):
             `ÌnteriorRing`
                 The removed interior ring variable.
 
-        **Examples:**
+        **Examples**
 
 
         >>> c = {{package}}.{{class}}()
@@ -347,7 +347,7 @@ class PropertiesDataBounds(PropertiesData):
             `Bounds`
                 The bounds.
 
-        **Examples:**
+        **Examples**
 
 
         >>> c = {{package}}.{{class}}()
@@ -397,7 +397,7 @@ class PropertiesDataBounds(PropertiesData):
             `str`
                 The geometry type.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.read('file.nc')[0]
         >>> c = f.construct('axis=X')
@@ -449,7 +449,7 @@ class PropertiesDataBounds(PropertiesData):
             `InteriorRing`
                 The interior ring variable.
 
-        **Examples:**
+        **Examples**
 
 
         >>> c = {{package}}.{{class}}()
@@ -497,7 +497,7 @@ class PropertiesDataBounds(PropertiesData):
             `bool`
                 True if there are bounds, otherwise False.
 
-        **Examples:**
+        **Examples**
 
 
         >>> c = {{package}}.{{class}}()
@@ -532,7 +532,7 @@ class PropertiesDataBounds(PropertiesData):
             `bool`
                 Whether or not there is a geometry type.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.read('file.nc')[0]
         >>> c = f.construct('axis=X')
@@ -567,7 +567,7 @@ class PropertiesDataBounds(PropertiesData):
                 True if there is an interior ring variable, otherwise
                 False.
 
-        **Examples:**
+        **Examples**
 
 
         >>> c = {{package}}.{{class}}()
@@ -613,7 +613,7 @@ class PropertiesDataBounds(PropertiesData):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
 
         >>> c = {{package}}.{{class}}()
@@ -666,7 +666,7 @@ class PropertiesDataBounds(PropertiesData):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.read('file.nc')[0]
         >>> c = f.construct('axis=X')
@@ -708,7 +708,7 @@ class PropertiesDataBounds(PropertiesData):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
 
         >>> c = {{package}}.{{class}}()

--- a/cfdm/core/auxiliarycoordinate.py
+++ b/cfdm/core/auxiliarycoordinate.py
@@ -43,7 +43,7 @@ class AuxiliaryCoordinate(abstract.Coordinate):
             `str`
                 The construct type.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.construct_type

--- a/cfdm/core/cellmeasure.py
+++ b/cfdm/core/cellmeasure.py
@@ -94,7 +94,7 @@ class CellMeasure(abstract.PropertiesData):
             `str`
                 The construct type.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.construct_type
@@ -122,7 +122,7 @@ class CellMeasure(abstract.PropertiesData):
 
                 The removed measure.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_measure('area')
@@ -154,7 +154,7 @@ class CellMeasure(abstract.PropertiesData):
              `bool`
                 True if the measure has been set, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_measure('area')
@@ -193,7 +193,7 @@ class CellMeasure(abstract.PropertiesData):
 
                 The value of the measure.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_measure('area')
@@ -229,7 +229,7 @@ class CellMeasure(abstract.PropertiesData):
 
              `None`
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_measure('area')

--- a/cfdm/core/cellmethod.py
+++ b/cfdm/core/cellmethod.py
@@ -130,7 +130,7 @@ class CellMethod(abstract.Container):
             `str`
                 The construct type.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.construct_type
@@ -163,7 +163,7 @@ class CellMethod(abstract.Container):
                 The removed axes, identified by domain axis construct key
                 or standard name.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_axes('domainaxis1')
@@ -202,7 +202,7 @@ class CellMethod(abstract.Container):
             `str`
                 The removed method.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_method('minimum')
@@ -247,7 +247,7 @@ class CellMethod(abstract.Container):
 
                 The removed qualifier.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_qualifier('where', 'land')
@@ -292,7 +292,7 @@ class CellMethod(abstract.Container):
             `tuple`
                 The axes.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_axes('domainaxis1')
@@ -332,7 +332,7 @@ class CellMethod(abstract.Container):
             `str`
                 The method.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_method('minimum')
@@ -378,7 +378,7 @@ class CellMethod(abstract.Container):
 
                 The value of the qualifier.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_qualifier('where', 'land')
@@ -415,7 +415,7 @@ class CellMethod(abstract.Container):
             `bool`
                 `True` if the axes have been set, otherwise `False`.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_axes('domainaxis1')
@@ -447,7 +447,7 @@ class CellMethod(abstract.Container):
             `bool`
                 `True` if the method has been set, otherwise `False`.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_method('minimum')
@@ -485,7 +485,7 @@ class CellMethod(abstract.Container):
             `bool`
                 `True` if the qualifier has been set, otherwise `False`.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_qualifier('where', 'land')
@@ -512,7 +512,7 @@ class CellMethod(abstract.Container):
             `dict`
                 The qualifiers.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_qualifier('where', 'land')
@@ -562,7 +562,7 @@ class CellMethod(abstract.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_axes('domainaxis1')
@@ -609,7 +609,7 @@ class CellMethod(abstract.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_method('minimum')
@@ -649,7 +649,7 @@ class CellMethod(abstract.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.set_qualifier('where', 'land')

--- a/cfdm/core/constructs.py
+++ b/cfdm/core/constructs.py
@@ -450,7 +450,7 @@ class Constructs(abstract.Container):
 
                 The removed construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(3)
         >>> c = f.constructs
@@ -572,7 +572,7 @@ class Constructs(abstract.Container):
              `str`
                 The construct identifier for the construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(3)
         >>> c = f.constructs
@@ -672,7 +672,7 @@ class Constructs(abstract.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(3)
         >>> c = f.constructs
@@ -822,7 +822,7 @@ class Constructs(abstract.Container):
                 The construct key and constructs respectively as
                 key-value pairs in a Python `dict_items` iterator.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> c = f.constructs
@@ -861,7 +861,7 @@ class Constructs(abstract.Container):
             `dict_keys`
                 The construct keys as a Python `dict_keys` iterator.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> c = f.constructs
@@ -900,7 +900,7 @@ class Constructs(abstract.Container):
             `dict_values`
                 The constructs as a Python `dict_values` iterator.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> c = f.constructs
@@ -988,7 +988,7 @@ class Constructs(abstract.Container):
             `{{class}}`
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> c = f.constructs
@@ -1018,7 +1018,7 @@ class Constructs(abstract.Container):
                 The keys of the domain axes constructs spanned by
                 metadata construct data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> c = f.constructs
@@ -1094,7 +1094,7 @@ class Constructs(abstract.Container):
             `{{class}}` or `dict`
                 The selected constructs and their construct keys.
 
-        **Examples:**
+        **Examples**
 
         Select dimension coordinate constructs:
 
@@ -1202,7 +1202,7 @@ class Constructs(abstract.Container):
             `str`
                 The construct key.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.Field()
         >>> c = f.constructs
@@ -1257,7 +1257,7 @@ class Constructs(abstract.Container):
             `str`
                 The new construct identifier.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> c = f.constructs
@@ -1308,7 +1308,7 @@ class Constructs(abstract.Container):
                  The constructs and their construct keys, in their
                  predetermined order.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.Field()
         >>> c = f.constructs
@@ -1371,7 +1371,7 @@ class Constructs(abstract.Container):
             `{{class}}`
                 The shallow copy.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> c = f.constructs
@@ -1433,7 +1433,7 @@ class Constructs(abstract.Container):
 
                 The metadata construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.Field()
         >>> c = f.constructs

--- a/cfdm/core/coordinatereference.py
+++ b/cfdm/core/coordinatereference.py
@@ -154,7 +154,7 @@ class CoordinateReference(abstract.Container):
             `str`
                 The construct type.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.construct_type
@@ -176,7 +176,7 @@ class CoordinateReference(abstract.Container):
             `CoordinateConversion`
                 The coordinate conversion.
 
-        **Examples:**
+        **Examples**
 
         >>> orog = {{package}}.DomainAncillary()
         >>> c = {{package}}.CoordinateConversion(
@@ -205,7 +205,7 @@ class CoordinateReference(abstract.Container):
            `Datum`
                 The datum.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.Datum(parameters={'earth_radius': 7000000})
         >>> r = {{package}}.{{class}}(datum=d)
@@ -232,7 +232,7 @@ class CoordinateReference(abstract.Container):
             `set`
                 The removed coordinate construct keys.
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> r.set_coordinates(['dimensioncoordinate0', 'auxiliarycoordinate1'])
@@ -260,7 +260,7 @@ class CoordinateReference(abstract.Container):
             `set`
                 The coordinate construct keys.
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> r.set_coordinates(['dimensioncoordinate0', 'auxiliarycoordinate1'])
@@ -286,7 +286,7 @@ class CoordinateReference(abstract.Container):
             `{{class}}`
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> s = r.copy()
@@ -321,7 +321,7 @@ class CoordinateReference(abstract.Container):
 
               The removed coordinate construct key.
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> r.set_coordinates(['dimensioncoordinate0', 'auxiliarycoordinate1'])
@@ -360,7 +360,7 @@ class CoordinateReference(abstract.Container):
             `CoordinateConversion`
                 The removed coordinate conversion component.
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> orog = {{package}}.DomainAncillary()
@@ -396,7 +396,7 @@ class CoordinateReference(abstract.Container):
             `Datum`
                 The removed datum component.
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> d = {{package}}.Datum(parameters={'earth_radius': 7000000})
@@ -427,7 +427,7 @@ class CoordinateReference(abstract.Container):
             `CoordinateConversion`
                 The coordinate conversion component.
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> orog = {{package}}.DomainAncillary()
@@ -465,7 +465,7 @@ class CoordinateReference(abstract.Container):
            `Datum`
                 The datum component.
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> d = {{package}}.Datum(parameters={'earth_radius': 7000000})
@@ -509,7 +509,7 @@ class CoordinateReference(abstract.Container):
                   `True` if the coordinate construct key has been set,
                   otherwise `False`.
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> r.set_coordinates(['dimensioncoordinate0', 'auxiliarycoordinate1'])
@@ -545,7 +545,7 @@ class CoordinateReference(abstract.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> r.set_coordinate('dimensioncoordinate0')
@@ -588,7 +588,7 @@ class CoordinateReference(abstract.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> r.set_coordinates(['dimensioncoordinate0', 'auxiliarycoordinate1'])
@@ -627,7 +627,7 @@ class CoordinateReference(abstract.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> orog = {{package}}.DomainAncillary()
@@ -673,7 +673,7 @@ class CoordinateReference(abstract.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> r = {{package}}.{{class}}()
         >>> d = {{package}}.Datum(parameters={'earth_radius': 7000000})

--- a/cfdm/core/data/abstract/array.py
+++ b/cfdm/core/data/abstract/array.py
@@ -62,7 +62,7 @@ class Array(Container):
 
         .. versionadded:: (cfdm) 1.7.0
 
-        **Examples:**
+        **Examples**
 
         >>> import copy
         >>> y = copy.deepcopy(x)
@@ -81,7 +81,7 @@ class Array(Container):
             `numpy.ndarray`
                 An independent numpy array of the data.
 
-        **Examples:**
+        **Examples**
 
         >>> n = a.array
         >>> isinstance(n, numpy.ndarray)
@@ -148,7 +148,7 @@ class Array(Container):
             `{{class}}`
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> b = a.copy()
 

--- a/cfdm/core/data/data.py
+++ b/cfdm/core/data/data.py
@@ -160,7 +160,7 @@ class Data(abstract.Container):
             `numpy.ndarray`
                 An independent numpy array of the data.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}([1, 2, 3.0], 'km')
         >>> n = d.array
@@ -185,7 +185,7 @@ class Data(abstract.Container):
     def dtype(self):
         """Data-type of the data elements.
 
-        **Examples:**
+        **Examples**
 
         >>> d.dtype
         dtype('float64')
@@ -205,7 +205,7 @@ class Data(abstract.Container):
     def ndim(self):
         """Number of data dimensions.
 
-        **Examples:**
+        **Examples**
 
         >>> d.shape
         (73, 96)
@@ -235,7 +235,7 @@ class Data(abstract.Container):
     def shape(self):
         """Tuple of data dimension sizes.
 
-        **Examples:**
+        **Examples**
 
         >>> d.shape
         (73, 96)
@@ -265,7 +265,7 @@ class Data(abstract.Container):
     def size(self):
         """Number of elements in the data.
 
-        **Examples:**
+        **Examples**
 
         >>> d.shape
         (73, 96)
@@ -313,7 +313,7 @@ class Data(abstract.Container):
             `{{class}}`
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> e = d.copy()
         >>> e = d.copy(array=False)
@@ -328,7 +328,7 @@ class Data(abstract.Container):
 
                 The array.
 
-        **Examples:**
+        **Examples**
 
         >>> old = d.del_data()
 
@@ -354,7 +354,7 @@ class Data(abstract.Container):
             `str`
                 The value of the deleted calendar.
 
-        **Examples:**
+        **Examples**
 
         >>> d.set_calendar('360_day')
         >>> d.has_calendar()
@@ -399,7 +399,7 @@ class Data(abstract.Container):
 
                 The value of the deleted fill value.
 
-        **Examples:**
+        **Examples**
 
         >>> f.set_fill_value(-9999)
         >>> f.has_fill_value()
@@ -449,7 +449,7 @@ class Data(abstract.Container):
             `str`
                 The value of the deleted units.
 
-        **Examples:**
+        **Examples**
 
         >>> d.set_units('metres')
         >>> d.has_units()
@@ -495,7 +495,7 @@ class Data(abstract.Container):
             `str`
                 The calendar.
 
-        **Examples:**
+        **Examples**
 
         >>> d.set_calendar('360_day')
         >>> d.has_calendar()
@@ -539,7 +539,7 @@ class Data(abstract.Container):
 
                 The array object.
 
-        **Examples:**
+        **Examples**
 
         >>> a = d._get_Array(None)
 
@@ -572,7 +572,7 @@ class Data(abstract.Container):
 
                 The fill value.
 
-        **Examples:**
+        **Examples**
 
         >>> f.set_fill_value(-9999)
         >>> f.has_fill_value()
@@ -622,7 +622,7 @@ class Data(abstract.Container):
             `str`
                 The units.
 
-        **Examples:**
+        **Examples**
 
         >>> d.set_units('metres')
         >>> d.has_units()
@@ -659,7 +659,7 @@ class Data(abstract.Container):
             `bool`
                 True if units have been set, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> d.set_units('metres')
         >>> d.has_units()
@@ -690,7 +690,7 @@ class Data(abstract.Container):
             `bool`
                 True if the calendar has been set, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> d.set_calendar('360_day')
         >>> d.has_calendar()
@@ -720,7 +720,7 @@ class Data(abstract.Container):
             `bool`
                 True if a fill value has been set, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> f.set_fill_value(-9999)
         >>> f.has_fill_value()
@@ -759,7 +759,7 @@ class Data(abstract.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.set_calendar('360_day')
         >>> d.has_calendar()
@@ -791,7 +791,7 @@ class Data(abstract.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d._set_Array(a)
 
@@ -821,7 +821,7 @@ class Data(abstract.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f.set_fill_value(-9999)
         >>> f.has_fill_value()
@@ -862,7 +862,7 @@ class Data(abstract.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.set_units('metres')
         >>> d.has_units()
@@ -898,7 +898,7 @@ class Data(abstract.Container):
             subclass of `Array`
                 The underlying array object.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.read('file.nc')[0]
         >>> d = f.data

--- a/cfdm/core/data/numpyarray.py
+++ b/cfdm/core/data/numpyarray.py
@@ -35,7 +35,7 @@ class NumpyArray(abstract.Array):
 
         .. versionadded:: (cfdm) 1.7.0
 
-        **Examples:**
+        **Examples**
 
         >>> a.dtype
         dtype('float64')
@@ -51,7 +51,7 @@ class NumpyArray(abstract.Array):
 
         .. versionadded:: (cfdm) 1.7.0
 
-        **Examples:**
+        **Examples**
 
         >>> a.shape
         (73, 96)
@@ -88,7 +88,7 @@ class NumpyArray(abstract.Array):
             `numpy.ndarray`
                 An independent numpy array of the data.
 
-        **Examples:**
+        **Examples**
 
         >>> n = a.array
         >>> isinstance(n, numpy.ndarray)
@@ -124,7 +124,7 @@ class NumpyArray(abstract.Array):
             `{{class}}`
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> b = a.copy()
 

--- a/cfdm/core/dimensioncoordinate.py
+++ b/cfdm/core/dimensioncoordinate.py
@@ -46,7 +46,7 @@ class DimensionCoordinate(abstract.Coordinate):
             `str`
                 The construct type.
 
-        **Examples:**
+        **Examples**
 
         >>> c = {{package}}.{{class}}()
         >>> c.construct_type
@@ -88,7 +88,7 @@ class DimensionCoordinate(abstract.Coordinate):
                 otherwise return a new `{{class}}` instance containing the
                 new data.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.Data(range(10))
         >>> f.set_data(d)

--- a/cfdm/core/domain.py
+++ b/cfdm/core/domain.py
@@ -95,7 +95,7 @@ class Domain(mixin.FieldDomain, abstract.Properties):
             `str`
                 The construct type.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}()
         >>> d.construct_type
@@ -115,7 +115,7 @@ class Domain(mixin.FieldDomain, abstract.Properties):
             `Constructs`
                 The constructs.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.example_field(0)
         >>> print(d.constructs)
@@ -154,7 +154,7 @@ class Domain(mixin.FieldDomain, abstract.Properties):
             `{{class}}`
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}()
         >>> e = d.copy()
@@ -195,7 +195,7 @@ class Domain(mixin.FieldDomain, abstract.Properties):
 
                 The removed metadata construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f.del_construct('auxiliarycoordinate2')
         <{{repr}}AuxiliaryCoordinate: latitude(111, 106) degrees_north>
@@ -235,7 +235,7 @@ class Domain(mixin.FieldDomain, abstract.Properties):
             `{{class}}`
                 The domain created from a view of the constructs.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> d = {{package}}.{{class}}.fromconstructs(f.constructs)

--- a/cfdm/core/domainancillary.py
+++ b/cfdm/core/domainancillary.py
@@ -34,7 +34,7 @@ class DomainAncillary(abstract.PropertiesDataBounds):
             `str`
                 The construct type.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}()
         >>> d.construct_type

--- a/cfdm/core/domainaxis.py
+++ b/cfdm/core/domainaxis.py
@@ -61,7 +61,7 @@ class DomainAxis(abstract.Container):
             `str`
                 The construct type.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}()
         >>> d.construct_type
@@ -89,7 +89,7 @@ class DomainAxis(abstract.Container):
 
                 The removed size.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}(size=50)
         >>> d.has_size()
@@ -122,7 +122,7 @@ class DomainAxis(abstract.Container):
              `bool`
                 True if the size has been set, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}(size=50)
         >>> d.has_size()
@@ -162,7 +162,7 @@ class DomainAxis(abstract.Container):
 
                 The size.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}(size=50)
         >>> d.has_size()
@@ -199,7 +199,7 @@ class DomainAxis(abstract.Container):
 
              `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}(size=50)
         >>> d.has_size()

--- a/cfdm/core/field.py
+++ b/cfdm/core/field.py
@@ -137,7 +137,7 @@ class Field(mixin.FieldDomain, abstract.PropertiesData):
             `str`
                 The construct type.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.construct_type
@@ -157,7 +157,7 @@ class Field(mixin.FieldDomain, abstract.PropertiesData):
             `Constructs`
                 The constructs.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> print(f.constructs)
@@ -188,7 +188,7 @@ class Field(mixin.FieldDomain, abstract.PropertiesData):
             `Domain`
                 The domain.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(2)
         >>> f.domain
@@ -236,7 +236,7 @@ class Field(mixin.FieldDomain, abstract.PropertiesData):
                 The removed keys of the domain axis constructs spanned by
                 the data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> f.get_data_axes()
@@ -271,7 +271,7 @@ class Field(mixin.FieldDomain, abstract.PropertiesData):
             `Domain`
                  The domain.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(2)
         >>> f.get_domain()
@@ -316,7 +316,7 @@ class Field(mixin.FieldDomain, abstract.PropertiesData):
                 The keys of the domain axis constructs spanned by the
                 data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> f.get_data_axes()
@@ -364,7 +364,7 @@ class Field(mixin.FieldDomain, abstract.PropertiesData):
                 True if domain axis constructs that span the data been
                 set, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> f.get_data_axes()
@@ -426,7 +426,7 @@ class Field(mixin.FieldDomain, abstract.PropertiesData):
 
                 The removed metadata construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(4)
         >>> f.del_construct('auxiliarycoordinate2')
@@ -503,7 +503,7 @@ class Field(mixin.FieldDomain, abstract.PropertiesData):
                 otherwise return a new `{{class}}` instance containing the
                 new data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_data([1, 2, 3])
@@ -583,7 +583,7 @@ class Field(mixin.FieldDomain, abstract.PropertiesData):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         Set the domain axis constructs spanned by the data of the field
         construct:

--- a/cfdm/core/fieldancillary.py
+++ b/cfdm/core/fieldancillary.py
@@ -38,7 +38,7 @@ class FieldAncillary(abstract.PropertiesData):
             `str`
                 The construct type.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.construct_type

--- a/cfdm/core/functions.py
+++ b/cfdm/core/functions.py
@@ -30,7 +30,7 @@ def environment(display=True, paths=True):
             environment is printed and `None` is returned. Otherwise
             the description is returned as in a `list`.
 
-    **Examples:**
+    **Examples**
 
     >>> environment()
     Platform: Linux-4.15.0-72-generic-x86_64-with-debian-stretch-sid
@@ -89,7 +89,7 @@ def CF():
             The version of the CF conventions represented by this
             release of the cfdm.core package.
 
-    **Examples:**
+    **Examples**
 
     >>> cfdm.core.CF()
     '1.9'

--- a/cfdm/core/mixin/fielddomain.py
+++ b/cfdm/core/mixin/fielddomain.py
@@ -51,7 +51,7 @@ class FieldDomain(metaclass=DocstringRewriteMeta):
 
                 The removed metadata construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f.del_construct('dimensioncoordinate1')
         <{{repr}}DimensionCoordinate: grid_latitude(111) degrees>
@@ -85,7 +85,7 @@ class FieldDomain(metaclass=DocstringRewriteMeta):
 
                 The metadata construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f.constructs()
         {'auxiliarycoordinate0': <{{repr}}AuxiliaryCoordinate: latitude(10, 9) degree_N>,
@@ -130,7 +130,7 @@ class FieldDomain(metaclass=DocstringRewriteMeta):
             `bool`
                 True if the construct exists, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> f.has_construct('dimensioncoordinate1')
         True
@@ -188,7 +188,7 @@ class FieldDomain(metaclass=DocstringRewriteMeta):
              `str`
                 The construct identifier for the construct.
 
-        **Examples:**
+        **Examples**
 
         >>> key = f.set_construct(c)
         >>> key = f.set_construct(c, copy=False)
@@ -230,7 +230,7 @@ class FieldDomain(metaclass=DocstringRewriteMeta):
                 The keys of the domain axis constructs spanned by the
                 data.
 
-        **Examples:**
+        **Examples**
 
         >>> f.set_data_axes(['domainaxis0', 'domainaxis1'])
         >>> f.get_data_axes()
@@ -289,7 +289,7 @@ class FieldDomain(metaclass=DocstringRewriteMeta):
                 The removed keys of the domain axis constructs spanned
                 by the data.
 
-        **Examples:**
+        **Examples**
 
         >>> f.del_data_axes(key='dimensioncoordinate2')
         ('domainaxis1',)
@@ -340,7 +340,7 @@ class FieldDomain(metaclass=DocstringRewriteMeta):
                 True if domain axis constructs that span the data been
                 set, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> f.set_data_axes(['domainaxis0', 'domainaxis1'])
         >>> f.get_data_axes()
@@ -388,7 +388,7 @@ class FieldDomain(metaclass=DocstringRewriteMeta):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f.set_data_axes(['domainaxis0', 'domainaxis1'])
         >>> f.get_data_axes()

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -184,7 +184,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `numpy.ndarray`
                 An independent numpy array of the data.
 
-        **Examples:**
+        **Examples**
 
 
         >>> d = {{package}}.{{class}}([1, 2, 3])
@@ -224,7 +224,7 @@ class Data(Container, NetCDFHDF5, core.Data):
     def __format__(self, format_spec):
         """Interpret format specifiers for size 1 arrays.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}(9, 'metres')
         >>> f"{d}"
@@ -297,7 +297,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `{{class}}`
                 The subspace of the data.
 
-        **Examples:**
+        **Examples**
 
 
         >>> d = {{package}}.{{class}}(numpy.arange(100, 190).reshape(1, 10, 9))
@@ -367,7 +367,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
         x.__iter__() <==> iter(x)
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}([1, 2, 3], 'metres')
         >>> for e in d:
@@ -447,7 +447,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
 
         >>> d = {{package}}.{{class}}(numpy.arange(100, 190).reshape(1, 10, 9))
@@ -645,7 +645,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
                 The selected element of the data.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}([[1, 2, 3]], 'km')
         >>> x = d._item((0, -1))
@@ -684,7 +684,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
             `tuple`
 
-        **Examples:**
+        **Examples**
 
         >>> d._parse_axes(1)
         (1,)
@@ -731,7 +731,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d._set_Array(a)
 
@@ -760,7 +760,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d._set_CompressedArray(a)
 
@@ -844,7 +844,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `numpy.ndarray`
                 An independent numpy array of the compressed data.
 
-        **Examples:**
+        **Examples**
 
         >>> a = d.compressed_array
 
@@ -860,7 +860,7 @@ class Data(Container, NetCDFHDF5, core.Data):
     def data(self):
         """The data as an object identity.
 
-        **Examples:**
+        **Examples**
 
         >>> d.data is d
         True
@@ -893,7 +893,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `numpy.ndarray`
                 An independent numpy array of the date-time objects.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}([31, 62, 90], units='days since 2018-12-01')
         >>> a = d.datetime_array
@@ -972,7 +972,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `numpy.ndarray`
                 An independent numpy array of the date-time strings.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}([31, 62, 90], units='days since 2018-12-01')
         >>> print(d.datetime_as_string)
@@ -998,7 +998,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `{{class}}`
                 The Boolean mask as data.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}(numpy.ma.array(
         ...     [[280.0,   -99,   -99,   -99],
@@ -1034,7 +1034,7 @@ class Data(Container, NetCDFHDF5, core.Data):
                 `True` if any data array elements evaluate to True,
                 otherwise `False`.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}([[0, 0, 0]])
         >>> d.any()
@@ -1140,7 +1140,7 @@ class Data(Container, NetCDFHDF5, core.Data):
                 The data with masked values. If the operation was in-place
                 then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
 
         >>> d = {{package}}.{{class}}(numpy.arange(12).reshape(3, 4), 'm')
@@ -1283,7 +1283,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `{{class}}`
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> e = d.copy()
         >>> e = d.copy(array=False)
@@ -1314,7 +1314,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
             {{returns creation_commands}}
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}([[0.0, 45.0], [45.0, 90.0]],
         ...                           units='degrees_east')
@@ -1414,7 +1414,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `Data` or `None`
                 The filled data, or `None` if the operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}([[1, 2, 3]])
         >>> print(d.filled().array)
@@ -1488,7 +1488,7 @@ class Data(Container, NetCDFHDF5, core.Data):
                 The data with expanded axes. If the operation was in-place
                 then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> d.shape
         (19, 73, 96)
@@ -1539,7 +1539,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
                 The count variable.
 
-        **Examples:**
+        **Examples**
 
         >>> c = d.get_count()
 
@@ -1572,7 +1572,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
                 The index variable.
 
-        **Examples:**
+        **Examples**
 
         >>> i = d.get_index()
 
@@ -1602,7 +1602,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
                 The list variable.
 
-        **Examples:**
+        **Examples**
 
         >>> l = d.get_list()
 
@@ -1638,7 +1638,7 @@ class Data(Container, NetCDFHDF5, core.Data):
                 The position of the compressed dimension in the compressed
                 array.
 
-        **Examples:**
+        **Examples**
 
         >>> d.get_compressed_dimension()
         2
@@ -1663,7 +1663,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
             `list`
 
-        **Examples:**
+        **Examples**
 
 
         >>> d = {{package}}.{{class}}(numpy.arange(100, 190).reshape(1, 10, 9))
@@ -1781,7 +1781,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `{{class}}`
                 Maximum of the data along the specified axes.
 
-        **Examples:**
+        **Examples**
 
 
         >>> d = {{package}}.{{class}}(numpy.arange(24).reshape(1, 2, 3, 4))
@@ -1853,7 +1853,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `{{class}}`
                 Minimum of the data along the specified axes.
 
-        **Examples:**
+        **Examples**
 
 
         >>> d = {{package}}.{{class}}(numpy.arange(24).reshape(1, 2, 3, 4))
@@ -1931,7 +1931,7 @@ class Data(Container, NetCDFHDF5, core.Data):
                 The data with removed data axes. If the operation was
                 in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> d.shape
         (1, 73, 1, 96)
@@ -1999,7 +1999,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `{{class}}`
                 The sum of the data along the specified axes.
 
-        **Examples:**
+        **Examples**
 
 
         >>> d = {{package}}.{{class}}(numpy.arange(24).reshape(1, 2, 3, 4))
@@ -2072,7 +2072,7 @@ class Data(Container, NetCDFHDF5, core.Data):
                 The data with permuted data axes. If the operation was
                 in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> d.shape
         (19, 73, 96)
@@ -2131,7 +2131,7 @@ class Data(Container, NetCDFHDF5, core.Data):
                 dimension in the underlying array. If the data are not
                 compressed then an empty list is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> d.shape
         (2, 3, 4, 5, 6)
@@ -2167,7 +2167,7 @@ class Data(Container, NetCDFHDF5, core.Data):
                 The compression type. An empty string means that no
                 compression has been applied.
 
-        **Examples:**
+        **Examples**
 
         >>> d.get_compression_type()
         ''
@@ -2212,7 +2212,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
             `{{class}}`
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}.empty((96, 73))
 
@@ -2292,7 +2292,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `bool`
                 Whether the two data arrays are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> d.equals(d)
         True
@@ -2413,7 +2413,7 @@ class Data(Container, NetCDFHDF5, core.Data):
                 The file name in normalised, absolute form. If the
                 data is are memory then an empty `set` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> {{package}}.write(f, 'temp_file.nc')
@@ -2448,7 +2448,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
                 The first element of the data.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}(9.0)
         >>> x = d.first_element()
@@ -2615,7 +2615,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
                 The last element of the data.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}(9.0)
         >>> x = d.last_element()
@@ -2650,7 +2650,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
                 The second element of the data.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}([[1, 2], [3, 4]])
         >>> x = d.second_element()
@@ -2752,7 +2752,7 @@ class Data(Container, NetCDFHDF5, core.Data):
             `{{class}}`
                 The unique elements.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.{{class}}([[4, 2, 1], [1, 2, 3]], 'metre')
         >>> d.unique()

--- a/cfdm/data/mixin/arraymixin.py
+++ b/cfdm/data/mixin/arraymixin.py
@@ -18,7 +18,7 @@ class ArrayMixin:
             `numpy.ndarray`
                 An independent numpy array of the data.
 
-        **Examples:**
+        **Examples**
 
         >>> isinstance(a, Array)
         True
@@ -90,7 +90,7 @@ class ArrayMixin:
                 The compression type. An empty string means that no
                 compression has been applied.
 
-        **Examples:**
+        **Examples**
 
         >>> a.compression_type
         ''

--- a/cfdm/domainaxis.py
+++ b/cfdm/domainaxis.py
@@ -116,7 +116,7 @@ class DomainAxis(
 
             {{returns creation_commands}}
 
-        **Examples:**
+        **Examples**
 
         >>> x = {{package}}.DomainAxis(size=12)
         >>> x.nc_set_dimension('time')
@@ -192,7 +192,7 @@ class DomainAxis(
             `bool`
                 Whether the two domain axis constructs are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> d.equals(d)
         True
@@ -250,7 +250,7 @@ class DomainAxis(
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.DomainAxis(size=9)
         >>> d.nc_set_dimension('time')
@@ -302,7 +302,7 @@ class DomainAxis(
             `list` or generator
                 The identities.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.DomainAxis(size=9)
         >>> d.nc_set_dimension('time')

--- a/cfdm/examplefield.py
+++ b/cfdm/examplefield.py
@@ -58,7 +58,7 @@ def example_field(n, _implementation=_implementation):
             The example field construct, or if *n_field* is True, the
             number of field constructs that are available.
 
-    **Examples:**
+    **Examples**
 
     >>> f = cfdm.example_field(0)
     >>> print(f)
@@ -5253,7 +5253,7 @@ def example_domain(n, _func=example_field):
         `Domain`
             The example domain construct.
 
-    **Examples:**
+    **Examples**
 
     >>> f = cfdm.example_domain(0)
     >>> print(f)

--- a/cfdm/field.py
+++ b/cfdm/field.py
@@ -271,7 +271,7 @@ class Field(
             `Field`
                 The subspace of the field construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data.shape
         (1, 10, 9)
@@ -443,7 +443,7 @@ class Field(
 
                 {{Returns constructs}}
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.field_ancillaries())
         Constructs:
@@ -505,7 +505,7 @@ class Field(
 
                  {{Returns constructs}}
 
-        **Examples:**
+        **Examples**
 
         """
         cached = filter_kwargs.get("cached")
@@ -611,7 +611,7 @@ class Field(
                 A new field construct with masked values, or `None` if
                 the operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> f.data[[0, -1]] = numpy.ma.masked
@@ -664,7 +664,7 @@ class Field(
                 The axes on the field which are climatological time
                 axes. If there are none, this will be an empty set.
 
-        **Examples:**
+        **Examples**
 
         >>> f
         <{{repr}}Field: air_temperature(time(12), latitude(145), longitude(192)) K>
@@ -860,7 +860,7 @@ class Field(
                 The compressed field construct, or `None` if the
                 operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data.get_compression_type()
         ''
@@ -1295,7 +1295,7 @@ class Field(
 
             {{returns creation_commands}}
 
-        **Examples:**
+        **Examples**
 
         >>> q = {{package}}.example_field(0)
         >>> print(q)
@@ -1650,7 +1650,7 @@ class Field(
                 The keys of the domain axis constructs spanned by the
                 data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> f.get_data_axes()
@@ -1690,7 +1690,7 @@ class Field(
             `Domain`
                  The domain.
 
-        **Examples:**
+        **Examples**
 
         >>> d = f.get_domain()
 
@@ -1721,7 +1721,7 @@ class Field(
                 the data are in memory then an empty `set` is
                 returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> {{package}}.write(f, 'temp_file.nc')
@@ -1748,7 +1748,7 @@ class Field(
     #                Whether or not there is a geometry type on any coordinate
     #                construct.
     #
-    #        **Examples:**
+    #        **Examples**
     #
     #        >>> f = {{package}}.Field()
     #        >>> f.has_geometry()
@@ -1801,7 +1801,7 @@ class Field(
                 The new field construct with expanded data axes. If
                 the operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data.shape
         (19, 73, 96)
@@ -1893,7 +1893,7 @@ class Field(
             `Field`
                 The new field construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.read('file.nc')[0]
         >>> print(f)
@@ -2057,7 +2057,7 @@ class Field(
                 The field construct with removed data axes. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data.shape
         (1, 73, 1, 96)
@@ -2123,7 +2123,7 @@ class Field(
                 The field construct with permuted data axes. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data.shape
         (19, 73, 96)
@@ -2240,7 +2240,7 @@ class Field(
                 The uncompressed field construct, or `None` if the
                 operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data.get_compression_type()
         'ragged contiguous'

--- a/cfdm/functions.py
+++ b/cfdm/functions.py
@@ -82,7 +82,7 @@ def configuration(atol=None, rtol=None, log_level=None):
             of the project-wide constants prior to the change, or the
             current names and values if no new values are specified.
 
-    **Examples:**
+    **Examples**
 
     View full global configuration of constants:
 
@@ -312,7 +312,7 @@ def environment(display=True, paths=True):
             environment is printed and `None` is returned. Otherwise
             the description is returned as in a `list`.
 
-    **Examples:**
+    **Examples**
 
     >>> cfdm.environment()
     Platform: Linux-4.15.0-72-generic-x86_64-with-debian-stretch-sid
@@ -381,7 +381,7 @@ def CF():
             The version of the CF conventions represented by this
             release of the cfdm package.
 
-    **Examples:**
+    **Examples**
 
     >>> CF()
     '1.9'
@@ -408,7 +408,7 @@ def abspath(filename):
         `str`
             The normalised absolutised version of *filename*.
 
-    **Examples:**
+    **Examples**
 
     >>> import os
     >>> os.getcwd()
@@ -448,7 +448,7 @@ def unique_constructs(constructs, copy=True):
         `list`
             The unique constructs. May be an empty list.
 
-    **Examples:**
+    **Examples**
 
     >>> f = cfdm.example_field(0)
     >>> g = cfdm.example_field(1)
@@ -1194,7 +1194,7 @@ class atol(ConstantAccess):
             The value prior to the change, or the current value if no
             new value was specified.
 
-    **Examples:**
+    **Examples**
 
     >>> {{package}}.{{class}}()
     <{{repr}}Constant: 2.220446049250313e-16>
@@ -1279,7 +1279,7 @@ class rtol(ConstantAccess):
             The value prior to the change, or the current value if no
             new value was specified.
 
-    **Examples:**
+    **Examples**
 
     >>> {{package}}.{{class}}()
     <{{repr}}Constant: 2.220446049250313e-16>
@@ -1379,7 +1379,7 @@ class log_level(ConstantAccess):
             not valid). Note the string name, rather than the
             equivalent integer, will always be returned.
 
-    **Examples:**
+    **Examples**
 
     >>> {{package}}.{{class}}()
     <{{repr}}Constant: 'WARNING'>

--- a/cfdm/mixin/coordinate.py
+++ b/cfdm/mixin/coordinate.py
@@ -61,7 +61,7 @@ class Coordinate(PropertiesDataBounds):
 
             {{returns creation_commands}}
 
-        **Examples:**
+        **Examples**
 
         >>> x = {{package}}.{{class}}(
         ...     properties={'units': 'degrees_east',

--- a/cfdm/mixin/fielddomain.py
+++ b/cfdm/mixin/fielddomain.py
@@ -303,7 +303,7 @@ class FieldDomain:
 
         .. versionadded:: (cfdm) 1.7.0
 
-        **Examples:**
+        **Examples**
 
         >>> f._unique_construct_names()
         {'cellmethod0': 'method:mean',
@@ -344,7 +344,7 @@ class FieldDomain:
 
         .. versionadded:: (cfdm) 1.7.0
 
-        **Examples:**
+        **Examples**
 
         >>> f._unique_domain_axis_identities()
         {'domainaxis0': 'latitude(5)',
@@ -407,7 +407,7 @@ class FieldDomain:
 
                 {{Returns constructs}}
 
-        **Examples:**
+        **Examples**
 
         >>> f.auxiliary_coordinates()
         Constructs:
@@ -463,7 +463,7 @@ class FieldDomain:
 
                 {{Returns constructs}}
 
-        *Examples:**
+        *Examples**
 
         >> f.coordinates()
         Constructs:
@@ -519,7 +519,7 @@ class FieldDomain:
 
                 {{Returns constructs}}
 
-        **Examples:**
+        **Examples**
 
         >>> f.coordinate_references()
         Constructs:
@@ -581,7 +581,7 @@ class FieldDomain:
 
                 The removed metadata construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> print(f)
@@ -653,7 +653,7 @@ class FieldDomain:
 
                 {{Returns constructs}}
 
-        **Examples:**
+        **Examples**
 
         >>> f.dimension_coordinates()
         Constructs:
@@ -717,7 +717,7 @@ class FieldDomain:
 
                 {{Returns constructs}}
 
-        **Examples:**
+        **Examples**
 
         """
         return self.constructs.domain_axes(*identities, **filter_kwargs)
@@ -753,7 +753,7 @@ class FieldDomain:
 
                 {{Returns constructs}}
 
-        **Examples:**
+        **Examples**
 
         >>> f.domain_ancillaries()
         Constructs:
@@ -807,7 +807,7 @@ class FieldDomain:
 
                 {{Returns constructs}}
 
-        **Examples:**
+        **Examples**
 
         >>> f.cell_measures()
         Constructs:
@@ -862,7 +862,7 @@ class FieldDomain:
 
                 The selected construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_{{class_lower}}(0)
 
@@ -941,7 +941,7 @@ class FieldDomain:
             `tuple`
                 The selected construct and its construct identifier.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_{{class_lower}}(0)
 
@@ -1020,7 +1020,7 @@ class FieldDomain:
             `str`
                 The identifier of the selected construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_{{class_lower}}(0)
 
@@ -1096,7 +1096,7 @@ class FieldDomain:
                 The key of the domain axis construct that is spanned by
                 the data of the selected 1-d coordinate constructs.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.constructs())
         Constructs:
@@ -1233,7 +1233,7 @@ class FieldDomain:
             `bool`
                 Whether the two constructs are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> f.equals(f)
         True
@@ -1335,7 +1335,7 @@ class FieldDomain:
 
                 Whether or not a unique construct can be identified.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> print(f)
@@ -1367,7 +1367,7 @@ class FieldDomain:
             `bool`
                 True if there are geometries, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.has_geometry()

--- a/cfdm/mixin/parameters.py
+++ b/cfdm/mixin/parameters.py
@@ -80,7 +80,7 @@ class Parameters(Container):
             `bool`
                Whether the two instances are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> d.equals(d)
         True

--- a/cfdm/mixin/parametersdomainancillaries.py
+++ b/cfdm/mixin/parametersdomainancillaries.py
@@ -84,7 +84,7 @@ class ParametersDomainAncillaries(Parameters):
             `bool`
                 Whether the two instances are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> c.equals(c)
         True

--- a/cfdm/mixin/properties.py
+++ b/cfdm/mixin/properties.py
@@ -127,7 +127,7 @@ class Properties(Container):
 
             {{returns creation_commands}}
 
-        **Examples:**
+        **Examples**
 
         >>> x = {{package}}.{{class}}(
         ...     properties={'units': 'Kelvin',
@@ -293,7 +293,7 @@ class Properties(Container):
             `bool`
                 Whether the two instances are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> p.equals(p)
         True
@@ -391,7 +391,7 @@ class Properties(Container):
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.set_properties({'foo': 'bar',
@@ -467,7 +467,7 @@ class Properties(Container):
             `list` or generator
                 The identities.
 
-        **Examples:**
+        **Examples**
 
         >>> f.properties()
         {'foo': 'bar',

--- a/cfdm/mixin/propertiesdata.py
+++ b/cfdm/mixin/propertiesdata.py
@@ -55,7 +55,7 @@ class PropertiesData(Properties):
 
                 The subspace.
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (1, 10, 9)
@@ -193,7 +193,7 @@ class PropertiesData(Properties):
     def dtype(self):
         """Data-type of the data elements.
 
-        **Examples:**
+        **Examples**
 
         >>> d.dtype
         dtype('float64')
@@ -215,7 +215,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `data`, `has_data`, `isscalar`, `shape`, `size`
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (73, 96)
@@ -260,7 +260,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `data`, `has_data`, `ndim`, `size`
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (73, 96)
@@ -305,7 +305,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `data`, `has_data`, `ndim`, `shape`
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (73, 96)
@@ -395,7 +395,7 @@ class PropertiesData(Properties):
                 A new instance with masked values, or `None` if the
                 operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> print(v.data.array)
         [9.96920997e+36, 9.96920997e+36, 9.96920997e+36, 9.96920997e+36,
@@ -480,7 +480,7 @@ class PropertiesData(Properties):
 
             {{returns creation_commands}}
 
-        **Examples:**
+        **Examples**
 
         >>> x = {{package}}.{{class}}(
         ...     properties={'units': 'Kelvin',
@@ -671,7 +671,7 @@ class PropertiesData(Properties):
             `bool`
                 Whether the two instances are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> x.equals(x)
         True
@@ -801,7 +801,7 @@ class PropertiesData(Properties):
                 A new instance with expanded data axes. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (19, 73, 96)
@@ -846,7 +846,7 @@ class PropertiesData(Properties):
                 A new instance with removed size 1 one data axes. If
                 the operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
 
         >>> f = {{package}}.{{class}}()
@@ -919,7 +919,7 @@ class PropertiesData(Properties):
                 A new instance with permuted data axes. If the operation
                 was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (19, 73, 96)
@@ -973,7 +973,7 @@ class PropertiesData(Properties):
                 The uncompressed construct, or `None` if the operation
                 was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data.get_compression_type()
         'ragged contiguous'

--- a/cfdm/mixin/propertiesdatabounds.py
+++ b/cfdm/mixin/propertiesdatabounds.py
@@ -159,7 +159,7 @@ class PropertiesDataBounds(PropertiesData):
             `{{class}}`
                 The subspace of the construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (1, 10, 9)
@@ -268,7 +268,7 @@ class PropertiesDataBounds(PropertiesData):
     def dtype(self):
         """Data-type of the data elements.
 
-        **Examples:**
+        **Examples**
 
         >>> d.dtype
         dtype('float64')
@@ -294,7 +294,7 @@ class PropertiesDataBounds(PropertiesData):
 
         .. seealso:: `data`, `has_data`, `isscalar`, `shape`, `size`
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (73, 96)
@@ -349,7 +349,7 @@ class PropertiesDataBounds(PropertiesData):
 
         .. seealso:: `data`, `has_data`, `ndim`, `size`
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (73, 96)
@@ -404,7 +404,7 @@ class PropertiesDataBounds(PropertiesData):
 
         .. seealso:: `data`, `has_data`, `ndim`, `shape`
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (73, 96)
@@ -495,7 +495,7 @@ class PropertiesDataBounds(PropertiesData):
                 A new instance with masked values, or `None` if the
                 operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> print(c.data.array)
         [9.96920997e+36, 9.96920997e+36, 9.96920997e+36, 9.96920997e+36,
@@ -590,7 +590,7 @@ class PropertiesDataBounds(PropertiesData):
 
             {{returns creation_commands}}
 
-        **Examples:**
+        **Examples**
 
         >>> x = {{package}}.{{class}}(
         ...     properties={'units': 'degrees_east',
@@ -708,7 +708,7 @@ class PropertiesDataBounds(PropertiesData):
             `NodeCount`
                 The removed node count variable.
 
-        **Examples:**
+        **Examples**
 
         >>> n = {{package}}.NodeCount(properties={'long_name': 'node counts'})
         >>> c.set_node_count(n)
@@ -754,7 +754,7 @@ class PropertiesDataBounds(PropertiesData):
             `PartNodeCount`
                 The removed part node count variable.
 
-        **Examples:**
+        **Examples**
 
         >>> p = {{package}}.PartNodeCount(properties={'long_name': 'part node counts'})
         >>> c.set_part_node_count(p)
@@ -938,7 +938,7 @@ class PropertiesDataBounds(PropertiesData):
             `bool`
                 Whether the two instances are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> p.equals(p)
         True
@@ -1073,7 +1073,7 @@ class PropertiesDataBounds(PropertiesData):
             `NodeCount`
                 The node count variable.
 
-        **Examples:**
+        **Examples**
 
         >>> n = {{package}}.NodeCount(properties={'long_name': 'node counts'})
         >>> c.set_node_count(n)
@@ -1120,7 +1120,7 @@ class PropertiesDataBounds(PropertiesData):
             `PartNodeCount`
                 The part node count variable.
 
-        **Examples:**
+        **Examples**
 
         >>> p = {{package}}.PartNodeCount(properties={'long_name': 'part node counts'})
         >>> c.set_part_node_count(p)
@@ -1158,7 +1158,7 @@ class PropertiesDataBounds(PropertiesData):
             `bool`
                 True if there is a node count variable, otherwise False.
 
-        **Examples:**
+        **Examples**
 
 
         >>> n = {{package}}.NodeCount(properties={'long_name': 'node counts'})
@@ -1189,7 +1189,7 @@ class PropertiesDataBounds(PropertiesData):
                 True if there is a part node count variable, otherwise
                 False.
 
-        **Examples:**
+        **Examples**
 
         >>> p = {{package}}.PartNodeCount(properties={'long_name': 'part node counts'})
         >>> c.set_part_node_count(p)
@@ -1239,7 +1239,7 @@ class PropertiesDataBounds(PropertiesData):
             `list` or generator
                 The identities.
 
-        **Examples:**
+        **Examples**
 
         >>> f.properties()
         {'foo': 'bar',
@@ -1307,7 +1307,7 @@ class PropertiesDataBounds(PropertiesData):
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> f.properties()
         {'foo': 'bar',
@@ -1375,7 +1375,7 @@ class PropertiesDataBounds(PropertiesData):
             `Bounds`
                 The bounds.
 
-        **Examples:**
+        **Examples**
 
         >>> b = {{package}}.Bounds(data={{package}}.Data(range(10).reshape(5, 2)))
         >>> c.set_bounds(b)
@@ -1432,7 +1432,7 @@ class PropertiesDataBounds(PropertiesData):
             `Data`
                 The bounds data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.example_field(0)
         >>> x = f.construct('latitude')
@@ -1495,7 +1495,7 @@ class PropertiesDataBounds(PropertiesData):
                 The new construct with expanded data axes. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (19, 73, 96)
@@ -1560,7 +1560,7 @@ class PropertiesDataBounds(PropertiesData):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> n = {{package}}.NodeCount(properties={'long_name': 'node counts'})
         >>> c.set_node_count(n)
@@ -1600,7 +1600,7 @@ class PropertiesDataBounds(PropertiesData):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> p = {{package}}.PartNodeCount(properties={'long_name':
         ...                                           'part node counts'})
@@ -1648,7 +1648,7 @@ class PropertiesDataBounds(PropertiesData):
                 The new construct with removed data axes. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (1, 73, 1, 96)
@@ -1752,7 +1752,7 @@ class PropertiesDataBounds(PropertiesData):
                 The new construct with permuted data axes. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (19, 73, 96)
@@ -1848,7 +1848,7 @@ class PropertiesDataBounds(PropertiesData):
                 The uncompressed construct, or `None` if the operation
                 was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data.get_compression_type()
         'ragged contiguous'

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -274,7 +274,7 @@ class NetCDFRead(IORead):
             `bool`
                 Whether or this variable is referenced by any other.
 
-        **Examples:**
+        **Examples**
 
         >>> r._is_unreferenced('tas')
         False
@@ -309,7 +309,7 @@ class NetCDFRead(IORead):
             `int`
                 The new reference count.
 
-        **Examples:**
+        **Examples**
 
         >>> r._reference('longitude', 'tas')
         1
@@ -341,7 +341,7 @@ class NetCDFRead(IORead):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> r.file_close()
 
@@ -382,7 +382,7 @@ class NetCDFRead(IORead):
             `netCDF4.Dataset`
                 A `netCDF4.Dataset` object for the file.
 
-        **Examples:**
+        **Examples**
 
         >>> r.file_open('file.nc')
 
@@ -493,7 +493,7 @@ class NetCDFRead(IORead):
             `bool`
                 `True` if the file is netCDF, otherwise `False`
 
-        **Examples:**
+        **Examples**
 
         >>> {{package}}.{{class}}.is_netcdf_file('file.nc')
         True
@@ -549,7 +549,7 @@ class NetCDFRead(IORead):
             `bool`
                 `True` if the file is CDL, otherwise `False`
 
-        **Examples:**
+        **Examples**
 
         >>> {{package}}.{{class}}.is_cdl_file('file.nc')
         False
@@ -595,7 +595,7 @@ class NetCDFRead(IORead):
 
                 The default fill value for the netCDF variable.
 
-        **Examples:**
+        **Examples**
 
         >>> n.default_netCDF_fill_value('ua')
         9.969209968386869e+36
@@ -1645,7 +1645,7 @@ class NetCDFRead(IORead):
             `str`
                 The word in its singular or plural form.
 
-        **Examples:**
+        **Examples**
 
         >>> n._plural([1, 2], 'property')
         'properties'
@@ -4055,7 +4055,7 @@ class NetCDFRead(IORead):
 
             `bool`
 
-        **Examples:**
+        **Examples**
 
             >>> n._is_char_or_string('regions')
             True
@@ -4078,7 +4078,7 @@ class NetCDFRead(IORead):
 
             `bool`
 
-        **Examples:**
+        **Examples**
 
             >>> n._is_char('regions')
             True
@@ -4330,7 +4330,7 @@ class NetCDFRead(IORead):
 
             `list`
 
-        **Examples:**
+        **Examples**
 
         >>> r._get_domain_axes('areacello')
         ['domainaxis0', 'domainaxis1']
@@ -5634,7 +5634,7 @@ class NetCDFRead(IORead):
 
             `list` of `dict`
 
-        **Examples:**
+        **Examples**
 
         >>> c = parse_cell_methods('t: minimum within years '
         ...                        't: mean over ENSO years)')
@@ -6226,7 +6226,7 @@ class NetCDFRead(IORead):
                 The list of netCDF dimension names spanned by the
                 netCDF variable.
 
-        **Examples:**
+        **Examples**
 
         >>> n._ncdimensions('humidity')
         ['time', 'lat', 'lon']
@@ -7805,7 +7805,7 @@ class NetCDFRead(IORead):
 
             `netCDF4._netCDF4.Dataset` or `netCDF4._netCDF4.Group`, `str`
 
-        **Examples:**
+        **Examples**
 
         >>> group, name = n._netCDF4_group(nc, 'time')
         >>> group.name, name

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -170,7 +170,7 @@ class NetCDFWrite(IOWrite):
             `numpy.ndarray`
                 The compressed numpy array.
 
-        **Examples:**
+        **Examples**
 
         >>> x = numpy.ma.array(numpy.arange(5), mask=[0]*2 + [1]*3)
         >>> c = n._numpy_compressed(x)
@@ -282,7 +282,7 @@ class NetCDFWrite(IOWrite):
 
             `numpy.ndarray`
 
-        **Examples:**
+        **Examples**
 
         >>> print(a, a.shape, a.dtype.itemsize)
         ['fu' 'bar'] (2,) 3
@@ -1199,7 +1199,7 @@ class NetCDFWrite(IOWrite):
 
             `dict`
 
-        **Examples:**
+        **Examples**
 
         >>> _write_bounds(c, ('dim2',))
         {'bounds': 'lat_bounds'}
@@ -1699,7 +1699,7 @@ class NetCDFWrite(IOWrite):
 
             `str`
 
-        **Examples:**
+        **Examples**
 
         w._remove_group_structure('lat')
         'lat'
@@ -1740,7 +1740,7 @@ class NetCDFWrite(IOWrite):
 
             `str`
 
-        **Examples:**
+        **Examples**
 
         w._groups('lat')
         ''
@@ -1804,7 +1804,7 @@ class NetCDFWrite(IOWrite):
 
             `dict`
 
-        **Examples:**
+        **Examples**
 
         >>> _write_part_node_count(c, b)
         {'part_node_count': 'pnc'}
@@ -2234,7 +2234,7 @@ class NetCDFWrite(IOWrite):
             `str`
                 The netCDF variable name of the field ancillary object.
 
-        **Examples:**
+        **Examples**
 
         >>> ncvar = _write_field_ancillary(f, 'fieldancillary2', anc)
 
@@ -4551,7 +4551,7 @@ class NetCDFWrite(IOWrite):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         See `cfdm.write` for examples.
 

--- a/cfdm/read_write/read.py
+++ b/cfdm/read_write/read.py
@@ -274,7 +274,7 @@ def read(
             The field constructs found in the dataset, or the domain
             constructs if *domain* is True. The list may be empty.
 
-    **Examples:**
+    **Examples**
 
     >>> x = cfdm.read('file.nc')
     >>> print(type(x))

--- a/cfdm/read_write/write.py
+++ b/cfdm/read_write/write.py
@@ -502,7 +502,7 @@ def write(
 
         `None`
 
-    **Examples:**
+    **Examples**
 
     >>> cfdm.write(f, 'file.nc')
 


### PR DESCRIPTION
Context provided in https://github.com/NCAS-CMS/cfdm/pull/168#discussion_r816407972. Via the command `find . -type f | xargs sed -i 's/Examples:/Examples/g'`, we go from:

```console
$ git grep "Examples" | wc -l
501
$ git grep "Examples:" | wc -l
380
```

to:

```console
$ git grep "Examples" | wc -l
501
$ git grep "Examples:" | wc -l
0
```