### PR TITLE
Documentation: avoid use of double negatives for clarity

### DIFF
--- a/cfdm/constructs.py
+++ b/cfdm/constructs.py
@@ -959,8 +959,8 @@ class Constructs(mixin.Container, core.Constructs):
         :Parameters:
 
             data: `bool`, optional
-                If False then do not copy data contained in the metadata
-                constructs. By default such data are copied.
+                If True (the default) then copy data contained in the
+                metadata constructs.
 
         :Returns:
 

--- a/cfdm/core/abstract/propertiesdata.py
+++ b/cfdm/core/abstract/propertiesdata.py
@@ -167,8 +167,8 @@ class PropertiesData(Properties):
         :Parameters:
 
             data: `bool`, optional
-                If False then do not copy data. By default data are
-                copied.
+                If True (the default) then copy data, else the
+                data is not copied.
 
         :Returns:
 
@@ -397,8 +397,8 @@ class PropertiesData(Properties):
                 {{data_like}}
 
             copy: `bool`, optional
-                If False then do not copy the data prior to insertion. By
-                default the data are copied.
+                If True (the default) then copy the data prior to
+                insertion, else the data is not copied.
 
             {{inplace: `bool`, optional (default True)}}
 

--- a/cfdm/core/abstract/propertiesdatabounds.py
+++ b/cfdm/core/abstract/propertiesdatabounds.py
@@ -606,8 +606,8 @@ class PropertiesDataBounds(PropertiesData):
                 The bounds to be inserted.
 
             copy: `bool`, optional
-                If False then do not copy the bounds prior to
-                insertion. By default the bounds are copied.
+                If True (the default) then copy the bounds prior to
+                insertion, else the bounds are not copied.
 
         :Returns:
 
@@ -701,8 +701,8 @@ class PropertiesDataBounds(PropertiesData):
                 The interior_ring to be inserted.
 
             copy: `bool`, optional
-                If False then do not copy the interior_ring prior to
-                insertion. By default the interior_ring are copied.
+                If True (the default) then copy the interior_ring
+                prior to insertion, else it is not copied.
 
         :Returns:
 

--- a/cfdm/core/constructs.py
+++ b/cfdm/core/constructs.py
@@ -102,9 +102,9 @@ class Constructs(abstract.Container):
                 constructs from those of *source*.
 
             copy: `bool`, optional
-                If False then do not deep copy metadata constructs
-                from those of *source* prior to initialisation. By
-                default such metadata constructs are deep copied.
+                If True (the default) then deep copy metadata constructs
+                from those of *source* prior to initialisation, else they
+                are not deep copied.
 
             _ignore: sequence of `str`, optional
                 Ignores the given construct types.
@@ -979,9 +979,7 @@ class Constructs(abstract.Container):
 
         :Parameters:
 
-            data: `bool`, optional
-                If False then do not copy data contained in the
-                metadata constructs. By default such data are copied.
+            {{data: `bool`, optional}}
 
         :Returns:
 

--- a/cfdm/core/coordinatereference.py
+++ b/cfdm/core/coordinatereference.py
@@ -618,10 +618,7 @@ class CoordinateReference(abstract.Container):
             coordinate_conversion: `CoordinateConversion`
                 The coordinate conversion component to be inserted.
 
-            copy: `bool`, optional
-                If False then do not copy the coordinate conversion prior
-                to insertion. By default the coordinate conversion is
-                copied.
+            {{copy: `bool`, optional}}
 
         :Returns:
 
@@ -665,9 +662,7 @@ class CoordinateReference(abstract.Container):
             datum: `Datum`
                 The datum component to be inserted.
 
-            copy: `bool`, optional
-                If False then do not copy the datum prior to insertion. By
-                default the datum is copied.
+            {{copy: `bool`, optional}}
 
         :Returns:
 

--- a/cfdm/core/data/data.py
+++ b/cfdm/core/data/data.py
@@ -305,8 +305,8 @@ class Data(abstract.Container):
         :Parameters:
 
             array: `bool`, optional
-                If False then do not copy the array. By default the array
-                is copied.
+                If True (the default) then copy the array, else the
+                array is not copied.
 
         :Returns:
 

--- a/cfdm/core/dimensioncoordinate.py
+++ b/cfdm/core/dimensioncoordinate.py
@@ -73,9 +73,7 @@ class DimensionCoordinate(abstract.Coordinate):
 
                 {{data_like}}
 
-            copy: `bool`, optional
-                If False then do not copy the data prior to insertion. By
-                default the data are copied.
+            {{data copy: `bool`, optional}}
 
             {{inplace: `bool`, optional (default True)}}
 

--- a/cfdm/core/docstring/docstring.py
+++ b/cfdm/core/docstring/docstring.py
@@ -116,4 +116,16 @@ _docstring_substitution_definitions = {
                 to a `Data` object, i.e. `numpy` array_like objects,
                 `Data` objects, and {{package}} instances that contain
                 `Data` objects.""",
+    # data: `bool`, optional
+    "{{data: `bool`, optional}}": """data: `bool`, optional
+                If True (the default) then copy data contained in the
+                metadata construct(s), else the data is not copied.""",
+    # (component-based) copy: `bool`, optional
+    "{{copy: `bool`, optional}}": """copy: `bool`, optional
+                If True (the default) then copy the component prior to
+                insertion, else it is not copied.""",
+    # data copy: `bool`, optional
+    "{{data copy: `bool`, optional}}": """copy: `bool`, optional
+                If True (the default) then copy the data prior to
+                insertion, else the data is not copied.""",
 }

--- a/cfdm/core/docstring/docstring.py
+++ b/cfdm/core/docstring/docstring.py
@@ -58,10 +58,9 @@ _docstring_substitution_definitions = {
                 raised instead.""",
     # inplace: `bool`, optional (default True)
     "{{inplace: `bool`, optional (default True)}}": """inplace: `bool`, optional:
-                If False then do not do the operation in-place and
-                return a new, modified `{{class}}` instance. By
-                default the operation is in-place and `None` is
-                returned.""",
+                If True (the default) then do the operation in-place and
+                return `None`. If False a new, modified `{{class}}`
+                instance is returned.""",
     # init properties
     "{{init properties: `dict`, optional}}": """properties: `dict`, optional
                 Set descriptive properties. The dictionary keys are
@@ -105,8 +104,8 @@ _docstring_substitution_definitions = {
                 initialisation with the `set_interior_ring` method.""",
     # init copy
     "{{init copy: `bool`, optional}}": """copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
+                If True (the default) deep copy input parameters prior
+                to initialisation. If False arguments are not deep
                 copied.""",
     # init source
     "{{init source}}": """Note that if *source* is a `{{class}}` instance then

--- a/cfdm/core/domain.py
+++ b/cfdm/core/domain.py
@@ -145,9 +145,7 @@ class Domain(mixin.FieldDomain, abstract.Properties):
 
         :Parameters:
 
-            data: `bool`, optional
-                If False then do not copy data. By default data are
-                copied.
+            {{data: `bool`, optional}}
 
         :Returns:
 

--- a/cfdm/core/field.py
+++ b/cfdm/core/field.py
@@ -488,9 +488,7 @@ class Field(mixin.FieldDomain, abstract.PropertiesData):
                 *Parameter example:*
                   ``axes=None``
 
-            copy: `bool`, optional
-                If False then do not copy the data prior to insertion. By
-                default the data are copied.
+            {{data copy: `bool`, optional}}
 
             {{inplace: `bool`, optional (default True)}}
 

--- a/cfdm/core/functions.py
+++ b/cfdm/core/functions.py
@@ -17,11 +17,13 @@ def environment(display=True, paths=True):
     :Parameters:
 
         display: `bool`, optional
-            If False then return the description of the environment as
-            a string. By default the description is printed.
+            If True (the default) then display the description of the
+            environment as a string. If False the description is
+            instead returned as a list.
 
         paths: `bool`, optional
-            If False then do not output the locations of each package.
+            If True (the default) then output the locations of each
+            package. If False the locations are not included.
 
     :Returns:
 

--- a/cfdm/data/abstract/raggedarray.py
+++ b/cfdm/data/abstract/raggedarray.py
@@ -83,10 +83,7 @@ class RaggedArray(CompressedArray):
 
                 {{init source}}
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.
+            {{deep copy}}
 
         """
         if count_variable is not None:

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -1272,8 +1272,8 @@ class Data(Container, NetCDFHDF5, core.Data):
         :Parameters:
 
             array: `bool`, optional
-                If False then do not copy the array. By default the array
-                is copied.
+                If True (the default) then copy the array, else it
+                is not copied.
 
         :Returns:
 

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -130,10 +130,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
                 {{init source}}
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.
+            {{deep copy}}
 
             kwargs: ignored
                 Not used. Present to facilitate subclassing.

--- a/cfdm/data/gatheredarray.py
+++ b/cfdm/data/gatheredarray.py
@@ -90,10 +90,7 @@ class GatheredArray(CompressedArray):
 
                 .. versionadded:: (cfdm) 1.9.TODO.0
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.
+            {{deep copy}}
 
                 .. versionadded:: (cfdm) 1.9.TODO.0
 

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -80,8 +80,8 @@ class NetCDFArray(abstract.Array):
                 The number of array dimensions in the netCDF file.
 
             mask: `bool`
-                If False then do not mask by convention when reading data
-                from disk. By default data is masked by convention.
+                If True (the default) then mask by convention when
+                reading data from disk.
 
                 A netCDF array is masked depending on the values of any of
                 the netCDF variable attributes ``valid_min``,

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -97,10 +97,7 @@ class NetCDFArray(abstract.Array):
 
                 .. versionadded:: (cfdm) 1.9.TODO.0
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.
+            {{deep copy}}
 
                 .. versionadded:: (cfdm) 1.9.TODO.0
 

--- a/cfdm/data/raggedcontiguousarray.py
+++ b/cfdm/data/raggedcontiguousarray.py
@@ -56,10 +56,7 @@ class RaggedContiguousArray(RaggedArray):
 
                 .. versionadded:: (cfdm) 1.9.TODO.0
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.
+            {{deep copy}}
 
                 .. versionadded:: (cfdm) 1.9.TODO.0
 

--- a/cfdm/data/raggedindexedarray.py
+++ b/cfdm/data/raggedindexedarray.py
@@ -57,10 +57,7 @@ class RaggedIndexedArray(RaggedArray):
 
                 .. versionadded:: (cfdm) 1.9.TODO.0
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.
+            {{deep copy}}
 
                 .. versionadded:: (cfdm) 1.9.TODO.0
 

--- a/cfdm/data/raggedindexedcontiguousarray.py
+++ b/cfdm/data/raggedindexedcontiguousarray.py
@@ -65,10 +65,7 @@ class RaggedIndexedContiguousArray(RaggedArray):
 
                 .. versionadded:: (cfdm) 1.9.TODO.0
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.
+            {{deep copy}}
 
                 .. versionadded:: (cfdm) 1.9.TODO.0
 

--- a/cfdm/data/subarray/abstract/subarray.py
+++ b/cfdm/data/subarray/abstract/subarray.py
@@ -66,10 +66,7 @@ class Subarray(Array):
 
                 {{init source}}
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.
+            {{deep copy}}
 
             context_manager: function, optional
                 A context manager that provides a runtime context for

--- a/cfdm/data/subarray/abstract/subsampledsubarray.py
+++ b/cfdm/data/subarray/abstract/subsampledsubarray.py
@@ -109,10 +109,7 @@ class SubsampledSubarray(Subarray):
 
                 {{init source}}
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.
+            {{deep copy}}
 
             context_manager: function, optional
                 A context manager that provides a runtime context for

--- a/cfdm/data/subarray/gatheredsubarray.py
+++ b/cfdm/data/subarray/gatheredsubarray.py
@@ -67,10 +67,7 @@ class GatheredSubarray(Subarray):
 
                 {{init source}}
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.
+            {{deep copy}}
 
             context_manager: function, optional
                 A context manager that provides a runtime context for

--- a/cfdm/data/subsampledarray.py
+++ b/cfdm/data/subsampledarray.py
@@ -249,10 +249,7 @@ class SubsampledArray(CompressedArray):
 
                 {{init source}}
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.
+            {{deep copy}}
 
         """
         super().__init__(

--- a/cfdm/docstring/docstring.py
+++ b/cfdm/docstring/docstring.py
@@ -112,8 +112,8 @@ _docstring_substitution_definitions = {
                   ``name='data1'``""",
     # header: `bool`, optional
     "{{header: `bool`, optional}}": """header: `bool`, optional
-                If False then do not output a comment describing the
-                components.""",
+                If True (the default) output a comment describing the
+                components. If False no such comment is returned.""",
     # ignore_compression: `bool`, optional
     "{{ignore_compression: `bool`, optional}}": """ignore_compression: `bool`, optional
                 If False then the compression type and, if applicable,

--- a/cfdm/docstring/docstring.py
+++ b/cfdm/docstring/docstring.py
@@ -345,6 +345,11 @@ _docstring_substitution_definitions = {
                 By default, *chunks* is ``-1``, meaning that all
                 non-compressed dimensions in each subarray have the
                 maximum possible size.""",
+    # deep copy
+    "{{deep copy}}": """copy: `bool`, optional
+                If False then do not deep copy input parameters prior
+                to initialisation. By default arguments are deep
+                copied.""",
     # ----------------------------------------------------------------
     # Method description susbstitutions (4 levels of indentataion)
     # ----------------------------------------------------------------

--- a/cfdm/docstring/docstring.py
+++ b/cfdm/docstring/docstring.py
@@ -347,9 +347,9 @@ _docstring_substitution_definitions = {
                 maximum possible size.""",
     # deep copy
     "{{deep copy}}": """copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.""",
+                If True (the default) then deep copy input
+                parameters prior to initialisation, else they are
+                not (deep) copied.""",
     # ----------------------------------------------------------------
     # Method description susbstitutions (4 levels of indentataion)
     # ----------------------------------------------------------------

--- a/cfdm/functions.py
+++ b/cfdm/functions.py
@@ -303,7 +303,8 @@ def environment(display=True, paths=True):
             a string. By default the description is printed.
 
         paths: `bool`, optional
-            If False then do not output the locations of each package.
+            If True (the default) then output the locations of each
+            package.
 
     :Returns:
 
@@ -440,8 +441,8 @@ def unique_constructs(constructs, copy=True):
             a mixture of types. The sequence can be empty.
 
         copy: `bool`, optional
-            If False then do not copy returned constructs. By default
-            they are deep copies.
+            If True (the default) then deep copy returned constructs,
+            else they are not (deep) copied.
 
     :Returns:
 

--- a/cfdm/mixin/propertiesdatabounds.py
+++ b/cfdm/mixin/propertiesdatabounds.py
@@ -1550,8 +1550,8 @@ class PropertiesDataBounds(PropertiesData):
                 The node count variable to be inserted.
 
             copy: `bool`, optional
-                If False then do not copy the node count variable
-                prior to insertion. By default it is copied.
+                If True (the default) then copy the node count
+                variable prior to insertion.
 
         :Returns:
 
@@ -1590,8 +1590,8 @@ class PropertiesDataBounds(PropertiesData):
                 The part node count variable to be inserted.
 
             copy: `bool`, optional
-                If False then do not copy the part node count variable
-                prior to insertion. By default it is copied.
+                If True (the default) then copy the part node count
+                variable prior to insertion.
 
         :Returns:
 

--- a/cfdm/mixin/propertiesdatabounds.py
+++ b/cfdm/mixin/propertiesdatabounds.py
@@ -95,10 +95,7 @@ class PropertiesDataBounds(PropertiesData):
 
                 {{init source}}
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior
-                to initialisation. By default arguments are deep
-                copied.
+            {{deep copy}}
 
         """
         # Initialise properties, data, geometry and interior ring

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -372,8 +372,8 @@ class NetCDFRead(IORead):
                 `netCDF.Dataset` instance.
 
             flatten: `bool`, optional
-                If False then do not flatten a grouped file. Ignored if
-                the file has no groups.
+                If True (the default) then flatten a grouped file.
+                Ignored if the file has no groups.
 
                 .. versionadded:: (cfdm) 1.8.6
 

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -4519,13 +4519,22 @@ class NetCDFWrite(IOWrite):
                 .. versionadded:: (cfdm) 1.8.0
 
             warn_valid: `bool`, optional
-                If False then do not print a warning when writing
+                If True (the default) then print a warning when writing
                 "out-of-range" data, as indicated by the values, if
                 present, of any of the ``valid_min``, ``valid_max`` or
                 ``valid_range`` properties on field and metadata
-                constructs that have data.
+                constructs that have data. If False the warning
+                is not printed.
 
-                See `cfdm.write` for details.
+                The consequence of writing out-of-range data values is
+                that, by default, these values will be masked when the
+                file is subsequently read.
+
+                *Parameter example:*
+                  If a construct has ``valid_max`` property with value
+                  ``100`` and data with maximum value ``999``, then the
+                  resulting warning may be suppressed by setting
+                  ``warn_valid=False``.
 
                 .. versionadded:: (cfdm) 1.8.3
 

--- a/cfdm/read_write/read.py
+++ b/cfdm/read_write/read.py
@@ -227,9 +227,8 @@ def read(
             .. versionadded:: (cfdm) 1.8.3
 
         mask: `bool`, optional
-            If False then do not mask by convention the data of field
-            and metadata constructs. By default all data is masked by
-            convention.
+            If True (the default) then mask by convention the data of
+            field and metadata constructs.
 
             The masking by convention of a netCDF array depends on the
             values of any of the netCDF variable attributes

--- a/cfdm/read_write/write.py
+++ b/cfdm/read_write/write.py
@@ -457,13 +457,12 @@ def write(
             and attributes.
 
        warn_valid: `bool`, optional
-            If False then do not print a warning when writing
+            If True (the default) then print a warning when writing
             "out-of-range" data, as indicated by the values, if
             present, of any of the ``valid_min``, ``valid_max`` or
             ``valid_range`` properties on field and metadata
-            constructs that have data. By default a warning is printed
-            if any such construct has any of these properties in
-            combination with out-of-range data.
+            constructs that have data. If False the warning
+            is not printed.
 
             The consequence of writing out-of-range data values is
             that, by default, these values will be masked when the


### PR DESCRIPTION
A documentation improvement discussed previously: see https://github.com/NCAS-CMS/cfdm/pull/168#discussion_r816857213 for context. This PR aims to find all uses of double negatives (in practice these are in keyword parameter descriptions) and reword them for clarity and conciseness. I have tried to use docstring substitutions wherever applicable i.e. duplicated text.

(Leaving this open in draft form for now, as I fear I may forget about it otherwise, but continue to have more pressing work to address. There are ~20 other cases from a `git grep "If False then do not" | wc -l` yet to be tackled, to complete this PR, but since we are fosucing mostly on cf-python at the moment I doubt many merge conflicts will arise if I leave this for a while.)