### PR TITLE
catch missing Array

### DIFF
--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -850,8 +850,7 @@ class Data(Container, NetCDFHDF5, core.Data):
 
         """
         ca = self._get_Array(None)
-
-        if not ca.get_compression_type():
+        if ca is None or not ca.get_compression_type():
             raise ValueError("not compressed: can't get compressed array")
 
         return ca.compressed_array


### PR DESCRIPTION
`cfdm.Data.compressed_array` fails if there is no Array returned by `_get_Array`, which is OK for cfdm but not for daskified cf-python, for which there sill usually not be an Array object. This PR simply traps this case instead and raises the nice exception.