### PR TITLE
Python 3.10: __wrapper__ attribute

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -19,6 +19,14 @@ Version 1.9.1.0
 
 ----
 
+Version 1.9.0.4
+---------------
+
+**2022-07-??**
+
+* Upgrade to allow cfdm to work with Python 3.10
+  (https://github.com/NCAS-CMS/cfdm/issues/187)
+
 Version 1.9.0.3
 ---------------
 

--- a/cfdm/core/meta/docstringrewrite.py
+++ b/cfdm/core/meta/docstringrewrite.py
@@ -197,10 +197,10 @@ class DocstringRewriteMeta(type):
             if is_classmethod:
                 attrs[attr_name] = classmethod(attr)
 
-            if is_staticmethod:
+            elif is_staticmethod:
                 attrs[attr_name] = staticmethod(attr)
 
-            if is_wrapped:
+            elif is_wrapped:
                 wrapper.__doc__ = attr.__doc__
                 wrapper.__wrapped__ = attr
                 attrs[attr_name] = wrapper


### PR DESCRIPTION
Partially fixes #187 

Adjustments for `__wrapper__` becoming read-only at Python 3.10.