### PR TITLE
Set correct `assertLogs` levels to fix Py 3.10+ `test_decorators`

### DIFF
--- a/cfdm/test/test_decorators.py
+++ b/cfdm/test/test_decorators.py
@@ -198,7 +198,7 @@ class decoratorsTest(unittest.TestCase):
             # Highest verbosity case (note -1 == 'DEBUG', highest verbosity):
             # all messages should appear, regardless of global log_level:
             for argument in (-1, "DEBUG", "debug", "Debug", "DeBuG"):
-                with self.assertLogs(level=cfdm.log_level().value) as catch:
+                with self.assertLogs(level=-1) as catch:
                     function_to_call_to_test(verbose=argument)
                     for msg in log_message:
                         self.assertIn(msg, catch.output)
@@ -207,7 +207,7 @@ class decoratorsTest(unittest.TestCase):
             # 'DISABLE' (see note above): only warning messages should appear,
             # regardless of global log_level value set:
             for argument in (1, "WARNING", "warning", "Warning", "WaRning"):
-                with self.assertLogs(level=cfdm.log_level().value) as catch:
+                with self.assertLogs(level=1) as catch:
                     function_to_call_to_test(verbose=argument)
                     for msg in log_message:
                         if msg.split(":")[0] == "WARNING":
@@ -218,7 +218,7 @@ class decoratorsTest(unittest.TestCase):
             # Boolean cases for testing backwards compatibility...
 
             # ... verbose=True should be equivalent to verbose=3 now:
-            with self.assertLogs(level=cfdm.log_level().value) as catch:
+            with self.assertLogs(level=3) as catch:
                 function_to_call_to_test(verbose=True)
                 for msg in log_message:
                     if msg.split(":")[0] == "DEBUG":


### PR DESCRIPTION
Addresses item two on the list in #187. It turns out that the issue at hand was in the `test_decorators` test `test_manage_log_level_via_verbosity` method code to check logging outputs, which was set up incorrectly for three cases with regards to the minimum logging level (`level` kwarg) being checked in the assertions which all relied on the [`assertLogs` method](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertLogs).

I'm not sure why said issue didn't appear with Python <3.10 versions, as nothing in the changelog for 3.10 suggests any behaviour change in that method or related aspects, but hey ho.

Probably doesn't require a review, as quite trivial, but feel free to look over it @davidhassell, else just merge straight in! I will add Python 3.10 to our Actions workflows shortly so we can test against 3.10.