### PR TITLE
Write fix to prevent vlen-strings being compressed with zlib

### DIFF
--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -2649,7 +2649,9 @@ class NetCDFWrite(IOWrite):
         if fill_value is not None:
             kwargs["fill_value"] = fill_value
 
-        kwargs.update(g["netcdf_compression"])
+        # Add compression parameters (but not for vlen strings).
+        if kwargs["datatype"] != str:
+            kwargs.update(g["netcdf_compression"])
 
         # Note: this is a trivial assignment in standalone cfdm, but required
         # for non-trivial customisation applied by subclasses e.g. in cf-python


### PR DESCRIPTION
Already merged into 1.9.0.4. See #200 for details.