### PR TITLE
 Fix for failure when printing date-time data with the first element masked

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,12 @@
+Version 1.10.0.1
+----------------
+
+**2022-??-??**
+
+* Fixed bug that caused a failure when printing date-time data with
+  the first element masked
+  (https://github.com/NCAS-CMS/cfdm/issues/211)
+
 Version 1.10.0.0
 ----------------
 

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -506,13 +506,13 @@ class Data(Container, NetCDFHDF5, core.Data):
 
         mask = [False, False, False]
 
+        if isreftime and first is np.ma.masked:
+            first = 0
+            mask[0] = True
+
         if size == 1:
             if isreftime:
                 # Convert reference time to date-time
-                if first is numpy.ma.masked:
-                    first = 0
-                    mask[0] = True
-
                 try:
                     first = type(self)(
                         numpy.ma.array(first, mask=mask[0]), units, calendar

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -506,13 +506,13 @@ class Data(Container, NetCDFHDF5, core.Data):
 
         mask = [False, False, False]
 
-        if isreftime and first is np.ma.masked:
-            first = 0
-            mask[0] = True
-
         if size == 1:
             if isreftime:
                 # Convert reference time to date-time
+                if first is numpy.ma.masked:
+                    first = 0
+                    mask[0] = True
+
                 try:
                     first = type(self)(
                         numpy.ma.array(first, mask=mask[0]), units, calendar

--- a/cfdm/test/test_Data.py
+++ b/cfdm/test/test_Data.py
@@ -73,6 +73,7 @@ class DataTest(unittest.TestCase):
         dt = numpy.ma.array([10, 20], mask=[True, False])
         d = cfdm.Data(dt, units="days since 2000-01-01")
         self.assertTrue(str(d) == "[--, 2000-01-21 00:00:00]")
+        self.assertTrue(repr(d) == "<Data(2): [--, 2000-01-21 00:00:00]>")
 
     #    def test_Data__getitem__(self):
     def test_Data__setitem__(self):

--- a/cfdm/test/test_Data.py
+++ b/cfdm/test/test_Data.py
@@ -68,12 +68,6 @@ class DataTest(unittest.TestCase):
             _ = repr(d)
             _ = str(d)
 
-        # Test when the data contains date-times with the first
-        # element masked
-        dt = numpy.ma.array([10, 20], mask=[True, False])
-        d = cfdm.Data(dt, units="days since 2000-01-01")
-        self.assertTrue(str(d) == "[--, 2000-01-21 00:00:00]")
-
     #    def test_Data__getitem__(self):
     def test_Data__setitem__(self):
         """Test the assignment of data items on Data."""

--- a/cfdm/test/test_Data.py
+++ b/cfdm/test/test_Data.py
@@ -68,6 +68,12 @@ class DataTest(unittest.TestCase):
             _ = repr(d)
             _ = str(d)
 
+        # Test when the data contains date-times with the first
+        # element masked
+        dt = numpy.ma.array([10, 20], mask=[True, False])
+        d = cfdm.Data(dt, units="days since 2000-01-01")
+        self.assertTrue(str(d) == "[--, 2000-01-21 00:00:00]")
+
     #    def test_Data__getitem__(self):
     def test_Data__setitem__(self):
         """Test the assignment of data items on Data."""


### PR DESCRIPTION
Fixes #211 