### PR TITLE
Test get_original_filenames in `cfdm.write`

### DIFF
--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -1625,6 +1625,20 @@ class CFDMImplementation(Implementation):
         """
         return cell_measure.get_measure(default=None)
 
+    def get_original_filenames(self, parent):
+        """Get the original names of the files containing the construct.
+
+        :Parameters:
+
+            parent:
+
+        :Returns:
+
+            `set`
+
+        """
+        return parent.get_original_filenames()
+
     def nc_get_dimension(self, parent, default=None):
         """Return the netCDF variable name.
 

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -1631,7 +1631,7 @@ class CFDMImplementation(Implementation):
         :Parameters:
 
             parent: Construct
-                The construct to query of roriginal filenames.
+                The construct to query of original filenames.
 
         :Returns:
 

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -1630,11 +1630,13 @@ class CFDMImplementation(Implementation):
 
         :Parameters:
 
-            parent:
+            parent: Construct
+                The construct to query of roriginal filenames.
 
         :Returns:
 
             `set`
+                The original filenames
 
         """
         return parent.get_original_filenames()

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -4289,7 +4289,11 @@ class NetCDFWrite(IOWrite):
                 `netCDF.Dataset` instance.
 
             fields: sequence of `Field` or `Domain`
-                The constructs to be written.
+                The constructs to be written to the netCDF file. Note
+                that these constructs are only used to ascertain if
+                any data to written be is in *filename*. If this is
+                the case and mode is "w" then an exception is raised
+                to prevent *filename* from being deleted.
 
         :Returns:
 
@@ -4297,13 +4301,13 @@ class NetCDFWrite(IOWrite):
                 A `netCDF4.Dataset` object for the file.
 
         """
-        if fields and mode != "r":
+        if fields and mode == "w":
             filename = os.path.abspath(filename)
             for f in fields:
                 if filename in self.implementation.get_original_filenames(f):
                     raise ValueError(
-                        "Can't write to a file that contains data "
-                        f"that needs to be read: {filename}"
+                        "Can't write with mode 'w' to a file that contains "
+                        f"data that needs to be read: {f!r} uses {filename}"
                     )
 
         # mode == 'w' is safer than != 'a' in case of a typo (the letters

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -4288,8 +4288,8 @@ class NetCDFWrite(IOWrite):
                 As for the *format* parameter for initialising a
                 `netCDF.Dataset` instance.
 
-            fields: sequence of `Field`
-                The field constructs to be written.
+            fields: sequence of `Field` or `Domain`
+                The constructs to be written.
 
         :Returns:
 
@@ -4300,7 +4300,7 @@ class NetCDFWrite(IOWrite):
         if fields and mode != "r":
             filename = os.path.abspath(filename)
             for f in fields:
-                if filename in self.implementation.get_filenames(f):
+                if filename in self.implementation.get_original_filenames(f):
                     raise ValueError(
                         "Can't write to a file that contains data "
                         f"that needs to be read: {filename}"

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -4291,7 +4291,7 @@ class NetCDFWrite(IOWrite):
             fields: sequence of `Field` or `Domain`
                 The constructs to be written to the netCDF file. Note
                 that these constructs are only used to ascertain if
-                any data to written be is in *filename*. If this is
+                any data to be written is in *filename*. If this is
                 the case and mode is "w" then an exception is raised
                 to prevent *filename* from being deleted.
 


### PR DESCRIPTION
Fixes #192.

Following on from discussions around https://github.com/NCAS-CMS/cf-python/issues/454, I think it makes sense to change the test to one for `get_original_filenames`, rather than deprecating `get_filenames` at this time.