### PR TITLE
Refactor `Field.compress` to help child implementations

### DIFF
--- a/cfdm/field.py
+++ b/cfdm/field.py
@@ -3,7 +3,6 @@ import logging
 import numpy as np
 
 from . import Constructs, Count, Domain, Index, List, core, mixin
-from .constants import masked as cfdm_masked
 from .data import (
     GatheredArray,
     RaggedContiguousArray,
@@ -1208,13 +1207,15 @@ class Field(
             flattened_data = data.flatten(range(data.ndim - 1))
 
             count = []
+            masked = np.ma.masked
             for d in flattened_data:
+                d = d.array
                 last = d.size
                 for i in d[::-1]:
-                    if i is not cfdm_masked:
+                    if i is not masked:
                         break
-                    else:
-                        last -= 1
+
+                    last -= 1
 
                 count.append(last)
 


### PR DESCRIPTION
This change, which has no effect on the functionality, is primarily so that the code plays nicely with cf-python+dask, but it's also probably faster, too!