### PR TITLE
Changes to facilitate CFA-netCDF 

### DIFF
--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -2170,9 +2170,19 @@ class CFDMImplementation(Implementation):
 
             mask: `bool`, optional
 
-            units: `str` or `None`, optional
+            units: `str` or `None` or False, optional
+                The units of the netCDF variable. Set to `None` to
+                indicate that there are no units. If False (the
+                default) then the units are considered unset.
+
+                .. versionadded:: (cfdm) 1.10.0.2
 
             calendar: `str` or `None`, optional
+                The calendar of the netCDF variable. By default, or if
+                set to `None`, then the CF default calendar is
+                assumed, if applicable.
+
+                .. versionadded:: (cfdm) 1.10.0.2
 
         :Returns:
 

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -2148,7 +2148,7 @@ class CFDMImplementation(Implementation):
         size=None,
         mask=True,
         units=False,
-            calendar=None,
+        calendar=None,
     ):
         """Return a netCDF array instance.
 
@@ -2190,7 +2190,7 @@ class CFDMImplementation(Implementation):
             size=size,
             mask=mask,
             units=units,
-            calendar=calendar
+            calendar=calendar,
         )
 
     def initialise_NodeCountProperties(self):

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -41,159 +41,6 @@ class CFDMImplementation(Implementation):
 
     """
 
-    def __init__(
-        self,
-        cf_version=None,
-        AuxiliaryCoordinate=None,
-        CellMeasure=None,
-        CellMethod=None,
-        CoordinateReference=None,
-        DimensionCoordinate=None,
-        Domain=None,
-        DomainAncillary=None,
-        DomainAxis=None,
-        Field=None,
-        FieldAncillary=None,
-        Bounds=None,
-        InteriorRing=None,
-        CoordinateConversion=None,
-        Datum=None,
-        Data=None,
-        GatheredArray=None,
-        NetCDFArray=None,
-        RaggedContiguousArray=None,
-        RaggedIndexedArray=None,
-        RaggedIndexedContiguousArray=None,
-        SubsampledArray=None,
-        List=None,
-        Count=None,
-        Index=None,
-        NodeCountProperties=None,
-        PartNodeCountProperties=None,
-        TiePointIndex=None,
-        InterpolationParameter=None,
-    ):
-        """**Initialisation**
-
-        :Parameters:
-
-            AuxiliaryCoordinate:
-                An auxiliary coordinate construct class.
-
-            CellMeasure:
-                A cell measure construct class.
-
-            CellMethod:
-                A cell method construct class.
-
-            CoordinateReference:
-                A coordinate reference construct class.
-
-            DimensionCoordinate:
-                A dimension coordinate construct class.
-
-            Domain:
-                A domain construct class.
-
-            DomainAncillary:
-                A domain ancillary construct class.
-
-            DomainAxis:
-                A domain axis construct class.
-
-            Field:
-                A field construct class.
-
-            FieldAncillary:
-                A field ancillary construct class.
-
-            Bounds:
-                A cell bounds component class.
-
-            InteriorRing:
-                An interior ring array class.
-
-            CoordinateConversion:
-                A coordinate conversion component class.
-
-            Datum:
-                A datum component class.
-
-            Data:
-                A data array class.
-
-            GatheredArray:
-                A class for an underlying gathered array.
-
-            NetCDFArray:
-                A class for an underlying array stored in a netCDF file.
-
-            RaggedContiguousArray:
-                A class for an underlying contiguous ragged array.
-
-            RaggedIndexedArray:
-                A class for an underlying indexed ragged array.
-
-            RaggedIndexedContiguousArray:
-                A class for an underlying indexed contiguous ragged array.
-
-            SubsampledArray:
-                A class for an underlying subsampled array.
-
-            List:
-                A list variable class.
-
-            Count:
-                A count variable class.
-
-            Index:
-                An index variable class.
-
-            NodeCountProperties:
-                A class for properties of a netCDF node count variable.
-
-            PartNodeCountProperties:
-                A class for properties of a netCDF part node count variable.
-
-            TiePointIndex:
-                A tie point index variable class.
-
-            InterpolationParameter:
-                An interpolation parameter variable class.
-
-        """
-        super().__init__(
-            cf_version=cf_version,
-            AuxiliaryCoordinate=AuxiliaryCoordinate,
-            CellMeasure=CellMeasure,
-            CellMethod=CellMethod,
-            CoordinateReference=CoordinateReference,
-            DimensionCoordinate=DimensionCoordinate,
-            Domain=Domain,
-            DomainAncillary=DomainAncillary,
-            DomainAxis=DomainAxis,
-            Field=Field,
-            FieldAncillary=FieldAncillary,
-            Bounds=Bounds,
-            InteriorRing=InteriorRing,
-            CoordinateConversion=CoordinateConversion,
-            Datum=Datum,
-            Data=Data,
-            GatheredArray=GatheredArray,
-            NetCDFArray=NetCDFArray,
-            RaggedContiguousArray=RaggedContiguousArray,
-            RaggedIndexedArray=RaggedIndexedArray,
-            RaggedIndexedContiguousArray=RaggedIndexedContiguousArray,
-            SubsampledArray=SubsampledArray,
-            List=List,
-            Count=Count,
-            Index=Index,
-            NodeCountProperties=NodeCountProperties,
-            PartNodeCountProperties=PartNodeCountProperties,
-            TiePointIndex=TiePointIndex,
-            InterpolationParameter=InterpolationParameter,
-        )
-
     def __repr__(self):
         """Called by the `repr` built-in function.
 
@@ -2300,6 +2147,8 @@ class CFDMImplementation(Implementation):
         shape=None,
         size=None,
         mask=True,
+        units=False,
+            calendar=None,
     ):
         """Return a netCDF array instance.
 
@@ -2321,6 +2170,10 @@ class CFDMImplementation(Implementation):
 
             mask: `bool`, optional
 
+            units: `str` or `None`, optional
+
+            calendar: `str` or `None`, optional
+
         :Returns:
 
             NetCDF array instance
@@ -2336,6 +2189,8 @@ class CFDMImplementation(Implementation):
             shape=shape,
             size=size,
             mask=mask,
+            units=units,
+            calendar=calendar
         )
 
     def initialise_NodeCountProperties(self):

--- a/cfdm/data/mixin/arraymixin.py
+++ b/cfdm/data/mixin/arraymixin.py
@@ -76,6 +76,35 @@ class ArrayMixin:
         """
         return 0
 
+    def get_calendar(self, default=ValueError()):
+        """The calendar of the array.
+
+        If the calendar is `None` then the CF default calendar is
+        assumed, if applicable.
+
+        .. versionadded:: (cfdm) 1.10.0.1
+
+        :Parameters:
+
+            TODO
+
+        :Returns:
+
+            `str` or `None`
+
+        """
+        calendar = self._get_component("calendar", False)
+        if calendar is False:
+            if default is None:
+                return
+
+            return self._default(
+                default,
+                f"{self.__class__.__name__} 'calendar' has not been set",
+            )
+
+        return calendar
+
     def get_compression_type(self):
         """Returns the array's compression type.
 
@@ -204,3 +233,31 @@ class ArrayMixin:
                 array = array.copy()
 
         return array
+
+    def get_units(self, default=ValueError()):
+        """The units of the array.
+
+        If the units are `None` then the array has no defined units.
+
+        .. versionadded:: (cfdm) 1.10.0.1
+
+        :Parameters:
+
+            TODO
+
+        :Returns:
+
+            `str` or `None`
+
+        """
+        units = self._get_component("units", False)
+        if units is False:
+            if default is None:
+                return
+
+            return self._default(
+                default,
+                f"{self.__class__.__name__} 'units' have not been set",
+            )
+
+        return units

--- a/cfdm/data/mixin/arraymixin.py
+++ b/cfdm/data/mixin/arraymixin.py
@@ -86,11 +86,15 @@ class ArrayMixin:
 
         :Parameters:
 
-            TODO
+            default: optional
+                Return the value of the *default* parameter if the
+                calendar has not been set. If set to an `Exception`
+                instance then it will be raised instead.
 
         :Returns:
 
             `str` or `None`
+                The calendar value.
 
         """
         calendar = self._get_component("calendar", False)
@@ -241,13 +245,19 @@ class ArrayMixin:
 
         .. versionadded:: (cfdm) 1.10.0.1
 
+        .. seealso:: `get_calendar`
+
         :Parameters:
 
-            TODO
+            default: optional
+                Return the value of the *default* parameter if the
+                units have not been set. If set to an `Exception`
+                instance then it will be raised instead.
 
         :Returns:
 
             `str` or `None`
+                The units value.
 
         """
         units = self._get_component("units", False)

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -24,7 +24,7 @@ class NetCDFArray(abstract.Array):
         size=None,
         mask=True,
         units=False,
-        calendar=False,
+        calendar=None,
         source=None,
         copy=True,
     ):
@@ -98,10 +98,10 @@ class NetCDFArray(abstract.Array):
 
                 .. versionadded:: (cfdm) 1.10.0.1
 
-            calendar: `str`, optional
-                The calendar of the netCDF variable.  Set to `None` to
-                indicate that there is no calendar, or the CF
-                default calendar if applicable.
+            calendar: `str` or `None`, optional
+                The calendar of the netCDF variable. By default, or if
+                set to `None`, then the CF default calendar is
+                assumed, if applicable.
 
                 .. versionadded:: (cfdm) 1.10.0.1
 
@@ -170,9 +170,9 @@ class NetCDFArray(abstract.Array):
                 units = False
 
             try:
-                calendar = source._get_component("calendar", False)
+                calendar = source._get_component("calendar", None)
             except AttributeError:
-                calendar = False
+                calendar = None
 
         if shape is not None:
             self._set_component("shape", shape, copy=False)
@@ -189,13 +189,9 @@ class NetCDFArray(abstract.Array):
         if units is not False:
             self._set_component("units", units, copy=False)
 
-        if calendar is not False:
-            self._set_component("calendar", calendar, copy=False)
-
         self._set_component("group", group, copy=False)
         self._set_component("dtype", dtype, copy=False)
         self._set_component("mask", mask, copy=False)
-        self._set_component("units", units, copy=False)
         self._set_component("calendar", calendar, copy=False)
 
         #        self._set_component("netcdf", None, copy=False)
@@ -424,15 +420,19 @@ class NetCDFArray(abstract.Array):
         return self._get_component("shape")
 
     def get_calendar(self):
-        """The calendar CF property.
+        """The calendar of the netCDF variable.
 
-        The calendar used for encoding time data. See
-        http://cfconventions.org/latest.html for details.
+        If the calendar is `None` then the CF default calendar is
+        assumed, if applicable.
 
         .. versionadded:: (cfdm) 1.10.0.1
 
+        :Returns:
+
+            `str` or `None`
+
         """
-        return self._get_component("calendar")
+        return self._get_component("calendar", None)
 
     def get_filename(self):
         """The name of the netCDF file containing the array.
@@ -492,13 +492,13 @@ class NetCDFArray(abstract.Array):
         return self._get_component("ncvar")
 
     def get_units(self):
-        """The units CF property.
-
-        The units of the data. The value of the `units` property is a
-        string that can be recognized by UNIDATA's Udunits
-        package. See http://cfconventions.org/latest.html for details.
+        """The units of the netCDF variable.
 
         .. versionadded:: (cfdm) 1.10.0.1
+
+        :Returns:
+
+            `str` or `None`
 
         """
         return self._get_component("units")

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -90,7 +90,7 @@ class NetCDFArray(abstract.Array):
                 ``valid_max``, ``valid_range``, ``_FillValue`` and
                 ``missing_value``.
 
-                .. versionadded:: (cfdm) 1.8.
+                .. versionadded:: (cfdm) 1.8.2
 
             units: `str` or `None`, optional
                 The units of the netCDF variable. Set to `None` to

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -417,7 +417,11 @@ class NetCDFArray(abstract.Array):
         return self._get_component("shape")
 
     def get_calendar(self):
-        """The calendar of the netCDF variable.
+        
+        return self._get_component("calendar", None)
+
+    def get_calendar(self, default=ValueError()):
+       """The calendar of the netCDF variable.
 
         If the calendar is `None` then the CF default calendar is
         assumed, if applicable.
@@ -428,13 +432,27 @@ class NetCDFArray(abstract.Array):
 
             `str` or `None`
 
-        """
-        return self._get_component("calendar", None)
+       """ 
+        try:
+            return self._get_component("calendar")
+        except AttributeError:
+            if default is None:
+                return
+
+            return self._default(
+                default,
+                f"{self.__class__.__name__} 'calendar' has not been set",
+            )
 
     def get_filename(self):
         """The name of the netCDF file containing the array.
 
         .. versionadded:: (cfdm) 1.7.0
+
+        :Returns:
+
+            `str` or `None`
+                The filename, or `None` if there isn't one.
 
         **Examples**
 
@@ -488,7 +506,7 @@ class NetCDFArray(abstract.Array):
         """
         return self._get_component("ncvar")
 
-    def get_units(self):
+    def get_units(self, default=ValueError()):
         """The units of the netCDF variable.
 
         .. versionadded:: (cfdm) 1.10.0.1
@@ -498,7 +516,16 @@ class NetCDFArray(abstract.Array):
             `str` or `None`
 
         """
-        return self._get_component("units")
+        try:
+            return self._get_component("units")
+        except AttributeError:
+            if default is None:
+                return
+
+            return self._default(
+                default,
+                f"{self.__class__.__name__} 'units' have not been set",
+            )
 
     def get_varid(self):
         """The UNIDATA netCDF interface ID of the array's variable.

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -295,26 +295,20 @@ class NetCDFArray(abstract.Array):
         return array
 
     def __repr__(self):
-        """Returns a printable representation of the `NetCDFArray`.
+        """Called by the `repr` built-in function.
 
-        x.__repr__() is logically equivalent to repr(x)
+        x.__repr__() <==> repr(x)
 
         """
         return f"<{self.__class__.__name__}{self.shape}: {self}>"
 
     def __str__(self):
-        """Returns a string version of the `NetCDFArray` object.
+        """Called by the `str` built-in function.
 
-        x.__str__() is logically equivalent to str(x)
+        x.__str__() <==> str(x)
 
         """
-        name = self.get_ncvar()
-        if name is None:
-            name = f"varid={self.get_varid()}"
-        else:
-            name = f"variable={name}"
-
-        return f"file={self.get_filename()} {name}"
+        return f"{self.get_filename()}, {self.get_address()}"
 
     def _set_units(self, var):
         """TODO.
@@ -416,34 +410,50 @@ class NetCDFArray(abstract.Array):
         """
         return self._get_component("shape")
 
+    def get_address(self):
+        """TODO
+
+        :Returns:
+
+            `str` or `None`
+                TODO, or `None` if there isn't one.
+
+        """
+        address = self.get_ncvar()
+        if address is None:
+            address = self.get_varid()
+
+        return address
+
     def get_calendar(self):
         
         return self._get_component("calendar", None)
 
     def get_calendar(self, default=ValueError()):
-       """The calendar of the netCDF variable.
-
+        """The calendar of the netCDF variable.
+        
         If the calendar is `None` then the CF default calendar is
         assumed, if applicable.
-
+        
         .. versionadded:: (cfdm) 1.10.0.1
-
+        
         :Returns:
-
+        
             `str` or `None`
-
-       """ 
-        try:
-            return self._get_component("calendar")
-        except AttributeError:
+        
+        """ 
+        calendar = self._get_component("calendar", False)
+        if calendar is False:
             if default is None:
                 return
-
+            
             return self._default(
                 default,
                 f"{self.__class__.__name__} 'calendar' has not been set",
             )
-
+        
+        return calendar
+    
     def get_filename(self):
         """The name of the netCDF file containing the array.
 
@@ -516,9 +526,8 @@ class NetCDFArray(abstract.Array):
             `str` or `None`
 
         """
-        try:
-            return self._get_component("units")
-        except AttributeError:
+        units = self._get_component("units", False)
+        if units is False:
             if default is None:
                 return
 
@@ -526,6 +535,8 @@ class NetCDFArray(abstract.Array):
                 default,
                 f"{self.__class__.__name__} 'units' have not been set",
             )
+
+        return units
 
     def get_varid(self):
         """The UNIDATA netCDF interface ID of the array's variable.
@@ -545,7 +556,7 @@ class NetCDFArray(abstract.Array):
         4
 
         """
-        return self._get_component("varid")
+        return self._get_component("varid", None)
 
     def close(self, netcdf):
         """Close the dataset containing the data.

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -24,7 +24,7 @@ class NetCDFArray(abstract.Array):
         size=None,
         mask=True,
         units=False,
-        calendar=None,
+        calendar=False,
         source=None,
         copy=True,
     ):
@@ -170,9 +170,9 @@ class NetCDFArray(abstract.Array):
                 units = False
 
             try:
-                calendar = source._get_component("calendar", None)
+                calendar = source._get_component("calendar", False)
             except AttributeError:
-                calendar = None
+                calendar = False
 
         if shape is not None:
             self._set_component("shape", shape, copy=False)
@@ -186,15 +186,11 @@ class NetCDFArray(abstract.Array):
         if varid is not None:
             self._set_component("varid", varid, copy=False)
 
-        if units is not False:
-            self._set_component("units", units, copy=False)
-
         self._set_component("group", group, copy=False)
         self._set_component("dtype", dtype, copy=False)
         self._set_component("mask", mask, copy=False)
+        self._set_component("units", units, copy=False)
         self._set_component("calendar", calendar, copy=False)
-
-        #        self._set_component("netcdf", None, copy=False)
 
         # By default, close the netCDF file after data array access
         self._set_component("close", True, copy=False)
@@ -248,9 +244,10 @@ class NetCDFArray(abstract.Array):
                     array = variable[indices]
                     break
 
-        #        self._set_units(variable)
+        self._set_units(variable)
 
         self.close(netcdf)
+        del netcdf
 
         string_type = isinstance(array, str)
         if string_type:
@@ -319,44 +316,44 @@ class NetCDFArray(abstract.Array):
 
         return f"file={self.get_filename()} {name}"
 
-    #    def _set_units(self, var):
-    #        """TODO.
-    #
-    #        .. versionadded:: (cfdm) 1.10.0.1
-    #
-    #        :Parameters:
-    #
-    #            var: `netCDF4.Variable`
-    #
-    #        :Returns:
-    #
-    #            `tuple`
-    #                The units and calendar attributes, either of which may
-    #                be `None`.
-    #
-    #        """
-    #        # Note: Can't use None as the default since it is a valid
-    #        #       `units` or 'calendar' value that indicates that the
-    #        #       attribute has not been set in the dataset.
-    #        units = self._get_component("units", False)
-    #        if units is False:
-    #            try:
-    #                units = var.getncattr("units")
-    #            except AttributeError:
-    #                units = None
-    #
-    #            self._set_component("units", units, copy=False)
-    #
-    #        calendar = self._get_component("calendar", False)
-    #        if calendar is False:
-    #            try:
-    #                calendar = var.getncattr("calendar")
-    #            except AttributeError:
-    #                calendar = None
-    #
-    #            self._set_component("calendar", units, copy=False)
-    #
-    #        return units, calendar
+    def _set_units(self, var):
+        """TODO.
+
+        .. versionadded:: (cfdm) 1.10.0.1
+
+        :Parameters:
+
+            var: `netCDF4.Variable`
+
+        :Returns:
+
+            `tuple`
+                The units and calendar attributes, either of which may
+                be `None`.
+
+        """
+        # Note: Can't use None as the default since it is a valid
+        #       `units` or 'calendar' value that indicates that the
+        #       attribute has not been set in the dataset.
+        units = self._get_component("units", False)
+        if units is False:
+            try:
+                units = var.getncattr("units")
+            except AttributeError:
+                units = None
+
+            self._set_component("units", units, copy=False)
+
+        calendar = self._get_component("calendar", False)
+        if calendar is False:
+            try:
+                calendar = var.getncattr("calendar")
+            except AttributeError:
+                calendar = None
+
+            self._set_component("calendar", calendar, copy=False)
+
+        return units, calendar
 
     @property
     def array(self):
@@ -445,7 +442,7 @@ class NetCDFArray(abstract.Array):
         'file.nc'
 
         """
-        return self._get_component("filename")
+        return self._get_component("filename", None)
 
     def get_group(self):
         """The netCDF4 group structure of the netCDF variable.

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -5686,7 +5686,7 @@ class NetCDFRead(IORead):
             array,
             units=units,
             calendar=calendar,
-            ncvar=ncvar,
+            ncvar=ncvar,            
         )
         data._original_filenames(define=filename)
 

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -5686,7 +5686,7 @@ class NetCDFRead(IORead):
             array,
             units=units,
             calendar=calendar,
-            ncvar=ncvar,            
+            ncvar=ncvar,
         )
         data._original_filenames(define=filename)
 

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -5296,7 +5296,7 @@ class NetCDFRead(IORead):
 
         :Returns:
 
-            (`NetCDFArray`, `dict`) or  (`None`, `dict`) or `dict`
+            (`NetCDFArray`, `dict`) or (`None`, `dict`) or `dict`
                 The new `NetCDFArray` instance and a dictionary of the
                 kwargs used to create it. If the array could not be
                 created then `None` is returned in its place. If

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -5350,22 +5350,7 @@ class NetCDFRead(IORead):
 
         filename = g["variable_filename"][ncvar]
 
-        # Find the group that this variable is in. The group will be
-        # None if the variable is in the root group.
-        if g["has_groups"]:
-            group = g["variable_groups"].get(ncvar, ())
-            if group:
-                # Make sure that we use the variable name without any
-                # group structure prepended to it
-                ncvar = g["variable_basename"][ncvar]
-        else:
-            # This variable is in the root group
-            group = None
-
-            # TODO: think using e.g. '/forecasts/model1' has the value for
-            # nc_set_variable. What about nc_set_dimension?
-
-        # Get the units and calendar
+        # Get the units and calendar (before we overwrite ncvar)
         units = g["variable_attributes"][ncvar].get("units")
         calendar = g["variable_attributes"][ncvar].get("calendar")
 
@@ -5379,6 +5364,21 @@ class NetCDFRead(IORead):
                 calendar = g["variable_attributes"][coord_ncvar].get(
                     "calendar"
                 )
+        # Find the group that this variable is in. The group will be
+        # None if the variable is in the root group.
+
+        if g["has_groups"]:
+            group = g["variable_groups"].get(ncvar, ())
+            if group:
+                # Make sure that we use the variable name without any
+                # group structure prepended to it
+                ncvar = g["variable_basename"][ncvar]
+        else:
+            # This variable is in the root group
+            group = None
+
+            # TODO: think using e.g. '/forecasts/model1' has the value for
+            # nc_set_variable. What about nc_set_dimension?
 
         kwargs = {
             "filename": filename,

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -5297,7 +5297,7 @@ class NetCDFRead(IORead):
         :Returns:
 
             (`NetCDFArray`, `dict`) or  (`None`, `dict`) or `dict`
-                The new `NetCDFArray` instance and dictionary of the
+                The new `NetCDFArray` instance and a dictionary of the
                 kwargs used to create it. If the array could not be
                 created then `None` is returned in its place. If
                 *return_kwargs_only* then only the dictionary is

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -5439,10 +5439,6 @@ class NetCDFRead(IORead):
         """
         g = self.read_vars
 
-        #        array, kwargs = self._ggg(ncvar, unpacked_dtype=unpacked_dtype)
-        #        if array is None:
-        #            return None
-
         array, kwargs = self._create_netcdfarray(
             ncvar, unpacked_dtype=unpacked_dtype, coord_ncvar=coord_ncvar
         )
@@ -5452,22 +5448,6 @@ class NetCDFRead(IORead):
         filename = kwargs["filename"]
         units = kwargs["units"]
         calendar = kwargs["calendar"]
-
-        #        units = g["variable_attributes"][ncvar].get("units", None)
-        #        calendar = g["variable_attributes"][ncvar].get("calendar", None)
-        #
-        #        if coord_ncvar:
-        #            # Get the Units from the parent coordinate variable, if
-        #            # they've not already been set.
-        #            if units is None:
-        #                units = g["variable_attributes"][coord_ncvar].get(
-        #                    "units", None
-        #                )
-        #
-        #            if calendar is None:
-        #                calendar = g["variable_attributes"][coord_ncvar].get(
-        #                    "calendar", None
-        #                )
 
         compression = g["compression"]
 


### PR DESCRIPTION
No functional changes to cfdm, but some changes that will allow the implementation of CFA in cf-python.

* Add `units` and `calendar` attributes to `NetCDFAarray`
* Populate these  `units` and `calendar` attributes in `NetCFDRead._create_netcdfarray`
* Add `get_units` and `get_calendar` methods to all `Array` subclasses
* Add `_set_units` method to `NetCDFAarray` that sets the units and calendar during a `__getitem__` call, if they've not already been set. It does this because it can cheaply grab them from the file whilst it is open. This is needed because CFA fragment array need to know their units, in case they are different to the aggregation variable's units.
* Add `get_address` method to  `NetCDFAarray`. This returns the file address as required for a CF fragment. 'varid' is is returned if   set 'ncvar' is not set. This goes beyond the CFA conventions at present, but is there for a legacy use case of JMG, either  won't   be required for CFA>=0.6, or else will be included as an enhancement to CFA.