### PR TITLE
Update subsampled compression to allow for use in downstream applications

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,12 @@
+Version 1.10.0.2
+----------------
+
+**202?-??-??**
+
+* New class: `cfdm.InterpolationSubarray`
+  (https://github.com/NCAS-CMS/cfdm/issues/???)
+* 
+
 Version 1.10.0.1
 ----------------
 

--- a/cfdm/__init__.py
+++ b/cfdm/__init__.py
@@ -135,6 +135,7 @@ from .data import (
     BiLinearSubarray,
     BiQuadraticLatitudeLongitudeSubarray,
     GatheredSubarray,
+    InterpolationSubarray,
     LinearSubarray,
     QuadraticLatitudeLongitudeSubarray,
     QuadraticSubarray,

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -2987,23 +2987,46 @@ class CFDMImplementation(Implementation):
         """
         return field.set_construct(construct, copy=copy)
 
-    def set_dependent_tie_points(self, construct, tie_points):
-        """TODO.
+    def set_dependent_tie_points(self, construct, tie_points, dimensions):
+        """Set dependent tie points and their dimensions.
+
+        This applies to arrays compressed by subsampling.
 
         .. versionadded:: (cfdm) 1.10.0.0
 
+        :Parameters:
+
+            construct:
+                The construct containing the ccompressed data. Will be
+                changed in-place.
+
+            tie_points: `dict`
+                The dependent tie point ararys, keyed by their
+                identities.
+
+            dimensions: `dict`
+                The dimensions spanned by the tie point ararys, keyed
+                by their identities.
+
+        :Returns:
+
+            `None`
+
         """
-        data = self.get_data_source(construct)
-        data.set_dependent_tie_points(tie_points)
+        data = self.get_data(construct)
+        source = data.source()
 
-    def set_dependent_tie_point_dimensions(self, construct, dimensions):
-        """TODO.
+        source.set_dependent_tie_points(tie_points)
+        source.set_dependent_tie_point_dimensions(dimensions)
 
-        .. versionadded:: (cfdm) 1.10.0.0
-
-        """
-        data = self.get_data_source(construct)
-        data.set_dependent_tie_point_dimensions(dimensions)
+        # Reset define the data with the new dependent tie point
+        # definitions
+        data = construct._Data(
+            source,
+            units=data.get_units(None),
+            calendar=data.get_calendar(None),
+        )
+        construct.set_data(data)
 
     def nc_set_external(self, construct):
         """Set the external status of a construct.

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -3019,12 +3019,11 @@ class CFDMImplementation(Implementation):
         source.set_dependent_tie_points(tie_points)
         source.set_dependent_tie_point_dimensions(dimensions)
 
-        # Reset define the data with the new dependent tie point
-        # definitions. Currently, cfdm doesn't need to do this, but it
-        # doesn't need to do this, but it doesn't hard do any harm and
-        # is generally a logical thing to do, as we shouldn't assume
-        # what the Data object instantitation does or doesn't do to
-        # its input arguments.
+        # Reset the construct's data with the new dependent tie point
+        # definitions. Currently cfdm doesn't need to do this, but it
+        # doesn't do any harm, and downstream applications (like
+        # cf-python) may not be able to correctly instantiate the data
+        # when all of its elements have not been set.
         data = construct._Data(
             source,
             units=data.get_units(None),

--- a/cfdm/cfdmimplementation.py
+++ b/cfdm/cfdmimplementation.py
@@ -3020,7 +3020,11 @@ class CFDMImplementation(Implementation):
         source.set_dependent_tie_point_dimensions(dimensions)
 
         # Reset define the data with the new dependent tie point
-        # definitions
+        # definitions. Currently, cfdm doesn't need to do this, but it
+        # doesn't need to do this, but it doesn't hard do any harm and
+        # is generally a logical thing to do, as we shouldn't assume
+        # what the Data object instantitation does or doesn't do to
+        # its input arguments.
         data = construct._Data(
             source,
             units=data.get_units(None),

--- a/cfdm/data/__init__.py
+++ b/cfdm/data/__init__.py
@@ -4,6 +4,7 @@ from .subarray import (
     BiLinearSubarray,
     BiQuadraticLatitudeLongitudeSubarray,
     GatheredSubarray,
+    InterpolationSubarray,
     LinearSubarray,
     QuadraticLatitudeLongitudeSubarray,
     QuadraticSubarray,

--- a/cfdm/data/subarray/__init__.py
+++ b/cfdm/data/subarray/__init__.py
@@ -3,6 +3,7 @@ from .gatheredsubarray import GatheredSubarray
 from .biquadraticlatitudelongitudesubarray import (
     BiQuadraticLatitudeLongitudeSubarray,
 )
+from .interpolationsubarray import InterpolationSubarray
 from .linearsubarray import LinearSubarray
 from .quadraticlatitudelongitudesubarray import (
     QuadraticLatitudeLongitudeSubarray,

--- a/cfdm/data/subarray/abstract/subsampledsubarray.py
+++ b/cfdm/data/subarray/abstract/subsampledsubarray.py
@@ -289,7 +289,8 @@ class SubsampledSubarray(Subarray):
             raise ValueError(
                 f"Must provide an identity for each of the "
                 f"{len(dependent_tie_points) + 1} codependent tie point "
-                f"arrays. Got {identities}"
+                f"arrays. Identites {identities} were provided, which "
+                f"should include the identities {tuple(dependent_tie_points)}"
             )
 
         if not set(dependent_tie_points).issubset(identities):

--- a/cfdm/data/subarray/abstract/subsampledsubarray.py
+++ b/cfdm/data/subarray/abstract/subsampledsubarray.py
@@ -29,6 +29,7 @@ class SubsampledSubarray(Subarray):
         first=None,
         parameters=None,
         dependent_tie_points=None,
+        interpolation_description=None,
         source=None,
         copy=True,
         context_manager=None,
@@ -104,6 +105,10 @@ class SubsampledSubarray(Subarray):
                 the dimension in the same position of the tie points
                 array.
 
+            interpolation_description: `str`, optional
+                A complete non-standardised description of the
+                interpolation method.
+
             source: optional
                 Initialise the subarray from the given object.
 
@@ -153,6 +158,13 @@ class SubsampledSubarray(Subarray):
             except AttributeError:
                 dependent_tie_points = {}
 
+            try:
+                interpolation_description = source._get_component(
+                    "interpolation_description", None
+                )
+            except AttributeError:
+                interpolation_description = None
+
         if subarea_indices is not None:
             self._set_component("subarea_indices", subarea_indices, copy=copy)
 
@@ -165,6 +177,13 @@ class SubsampledSubarray(Subarray):
         if dependent_tie_points is not None:
             self._set_component(
                 "dependent_tie_points", dependent_tie_points.copy(), copy=False
+            )
+
+        if interpolation_description is not None:
+            self._set_component(
+                "interpolation_description",
+                interpolation_description,
+                copy=False,
             )
 
     def _broadcast_bounds(self, u):
@@ -593,3 +612,30 @@ class SubsampledSubarray(Subarray):
 
         """
         return self._get_component("subarea_indices")
+
+    def get_interpolation_description(self, default=ValueError()):
+        """Get a non-standardised interpolation method description.
+
+        .. versionadded:: (cfdm) 1.10.0.2
+
+        :Parameters:
+
+            default: optional
+                Return the value of the *default* parameter if the
+                interpolation description has not been set.
+
+                {{default Exception}}
+
+        """
+        out = self._get_component("interpolation_description", None)
+        if out is None:
+            if default is None:
+                return
+
+            return self._default(
+                default,
+                f"{self.__class__.__name__!r} has no "
+                "'interpolation_description'",
+            )
+
+        return out

--- a/cfdm/data/subarray/interpolationsubarray.py
+++ b/cfdm/data/subarray/interpolationsubarray.py
@@ -1,0 +1,39 @@
+from .abstract import SubsampledSubarray
+
+
+class InterpolationSubarray(SubsampledSubarray):
+    """A subarray of an array compressed by subsamplng.
+
+    A subarray describes a unique part of the uncompressed array.
+
+    The subarray has no standardised interpolation algorithm. An
+    interpolation algorithm may have been provided via the
+    *interpolation_description* parameter, but that algorithm can not
+    be implemented by the {{class}} object. Nonetheless, the subarray
+    is still representable in its uncompressed form (e.g. its shape is
+    known,),even though the uncompressed data values can not be
+    calculated.
+
+    See CF section 8.3.3. "Interpolation Variable".
+
+    .. versionadded:: (cfdm) 1.10.0.2
+
+    """
+
+    def __getitem__(self, indices):
+        """Return a subspace of the uncompressed data.
+
+        x.__getitem__(indices) <==> x[indices]
+
+        Always raises a `ValueError`, rather than returning a subspace
+        of the uncompressed data as an independent numpy array, since
+        the interpolation algorithm is non-standardised.
+
+        .. versionadded:: (cfdm) 1.10.0.2
+
+        """
+        raise ValueError(
+            "Can't uncompress subsampled data using a non-standardised "
+            "interpolation algorithm:\n\n"
+            f"{self.get_interpolation_description('')}"
+        ) #from None

--- a/cfdm/data/subarray/interpolationsubarray.py
+++ b/cfdm/data/subarray/interpolationsubarray.py
@@ -9,12 +9,12 @@ class InterpolationSubarray(SubsampledSubarray):
     The subarray has no standardised interpolation algorithm. An
     interpolation algorithm may have been provided via the
     *interpolation_description* parameter, but that algorithm can not
-    be implemented by the {{class}} object. Nonetheless, the subarray
+    be interpreted by the {{class}} object. Nonetheless, the subarray
     is still representable in its uncompressed form (e.g. its shape is
-    known,),even though the uncompressed data values can not be
+    known), even though the uncompressed data values can not be
     calculated.
 
-    See CF section 8.3.3. "Interpolation Variable".
+    See CF section 8.3.3 "Interpolation Variable".
 
     .. versionadded:: (cfdm) 1.10.0.2
 
@@ -27,7 +27,8 @@ class InterpolationSubarray(SubsampledSubarray):
 
         Always raises a `ValueError`, rather than returning a subspace
         of the uncompressed data as an independent numpy array, since
-        the interpolation algorithm is non-standardised.
+        the non-standardised interpolation algorithm can't be
+        interpreted.
 
         .. versionadded:: (cfdm) 1.10.0.2
 
@@ -36,4 +37,4 @@ class InterpolationSubarray(SubsampledSubarray):
             "Can't uncompress subsampled data using a non-standardised "
             "interpolation algorithm:\n\n"
             f"{self.get_interpolation_description('')}"
-        ) #from None
+        )

--- a/cfdm/data/subsampledarray.py
+++ b/cfdm/data/subsampledarray.py
@@ -1,3 +1,4 @@
+from functools import partial
 from itertools import accumulate, product
 from numbers import Number
 
@@ -8,6 +9,7 @@ from .abstract import CompressedArray
 from .subarray import (
     BiLinearSubarray,
     BiQuadraticLatitudeLongitudeSubarray,
+    InterpolationSubarray,
     LinearSubarray,
     QuadraticLatitudeLongitudeSubarray,
     QuadraticSubarray,
@@ -96,6 +98,7 @@ class SubsampledArray(CompressedArray):
             "linear": LinearSubarray,
             "quadratic": QuadraticSubarray,
             "quadratic_latitude_longitude": QuadraticLatitudeLongitudeSubarray,
+            None: InterpolationSubarray,
         }
 
         return instance
@@ -793,6 +796,14 @@ class SubsampledArray(CompressedArray):
             raise ValueError(
                 "Can't get Subarray class when with unknown "
                 f"interpolation_name {interpolation_name!r}"
+            )
+
+        if interpolation_name is None:
+            Subarray = partial(
+                Subarray,
+                interpolation_description=self.get_interpolation_description(
+                    ""
+                ),
             )
 
         return Subarray

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -3430,15 +3430,11 @@ class NetCDFRead(IORead):
                     b_tp[identity] = self.implementation.get_tie_points(b)
                     break
 
-            self.implementation.set_dependent_tie_points(coord, c_tp)
-            self.implementation.set_dependent_tie_point_dimensions(
-                coord, tp_dims
-            )
+            self.implementation.set_dependent_tie_points(coord, c_tp, tp_dims)
 
             if bounds is not None:
-                self.implementation.set_dependent_tie_points(bounds, b_tp)
-                self.implementation.set_dependent_tie_point_dimensions(
-                    bounds, tp_dims
+                self.implementation.set_dependent_tie_points(
+                    bounds, b_tp, tp_dims
                 )
 
         # Set the coordinate constructs on the parent field/domain

--- a/cfdm/test/test_subsampling.py
+++ b/cfdm/test/test_subsampling.py
@@ -223,6 +223,24 @@ class GatheredTest(unittest.TestCase):
         # Check original filenames
         self.assertEqual(i.get_original_filenames(), set([self.biquadratic]))
 
+    def test_non_standard(self):
+        """Test non-standardised interpolation."""
+        f = cfdm.read(self.linear)
+
+        # Get a field with non-standardised coordinate interpolation
+        t = f[15]
+        self.assertEqual(t.nc_get_variable(), 't3')
+
+        # Check that the we can inspect the compressed data as if it
+        # were uncompressed
+        a_2d = t.construct('ncvar%a_2d')
+        self.assertEqual(a_2d.shape, (18, 12))
+        self.assertEqual(a_2d.get_property('units'), 'm')
+
+        # Check that we can't uncompress the data
+        with self.assertRaises(ValueError):
+            a_2d.array
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cfdm/test/test_subsampling.py
+++ b/cfdm/test/test_subsampling.py
@@ -229,13 +229,13 @@ class GatheredTest(unittest.TestCase):
 
         # Get a field with non-standardised coordinate interpolation
         t = f[15]
-        self.assertEqual(t.nc_get_variable(), 't3')
+        self.assertEqual(t.nc_get_variable(), "t3")
 
         # Check that the we can inspect the compressed data as if it
         # were uncompressed
-        a_2d = t.construct('ncvar%a_2d')
+        a_2d = t.construct("ncvar%a_2d")
         self.assertEqual(a_2d.shape, (18, 12))
-        self.assertEqual(a_2d.get_property('units'), 'm')
+        self.assertEqual(a_2d.get_property("units"), "m")
 
         # Check that we can't uncompress the data
         with self.assertRaises(ValueError):


### PR DESCRIPTION
When inheriting subsampled compression in cf-python, a few issues arose that can be remedied here.

* The need for a new `SubsampledSubarray` class that handles the case where no standardised interpolation algorithm has been specified (`InterpolationSubarray`).
* When reading files, the need to make sure that coordinate `Data` is inserted in a construct _after_ any dependent tie points have been set on the data source. cf-python needs this because of the way if creates `Data` objects - setting the dependent tie points afterwards means that they don't get picked up by the dask infrastructure.