### PR TITLE
Default branch rename from `master` to `main`

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,12 +3,12 @@ name: Linting
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     # default (from docs) is just on [opened, synchronize, reopened]
     types: [opened, reopened, ready_for_review, edited]
     branches:
-      - master
+      - main
 
 # Note: only running this on Ubuntu (latest) and Python 3.8 as representative,
 # since the linting output should be machine dependent and not vary much if

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -1,16 +1,16 @@
-# A GitHub Action to run the cfdm test suite after events on master.
+# A GitHub Action to run the cfdm test suite after events on main.
 name: Run test suite
 
-# Triggers the workflow on push or PR events for the master branch (only)
+# Triggers the workflow on push or PR events for the main branch (only)
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     # default (from docs) is just on [opened, synchronize, reopened]
     types: [opened, reopened, ready_for_review, edited]
     branches:
-      - master
+      - main
 
 # Note a workflow can have 1+ jobs that can run sequentially or in parallel.
 jobs:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Python reference implementation of the CF data model.
 [![PyPI](https://img.shields.io/pypi/v/cfdm?color=000000)](https://pypi.org/project/cfdm/)
 [![Conda](https://img.shields.io/conda/v/ncas/cfdm?color=000000)](https://ncas-cms.github.io/cfdm/installation.html#conda)
 
-[![Conda](https://img.shields.io/conda/pn/ncas/cfdm?color=2d8659)](https://ncas-cms.github.io/cfdm/installation.html#operating-systems) [![Website](https://img.shields.io/website?color=2d8659&down_message=online&label=documentation&up_message=online&url=https%3A%2F%2Fncas-cms.github.io%2Fcfdm%2F)](https://ncas-cms.github.io/cfdm/index.html) [![GitHub](https://img.shields.io/github/license/NCAS-CMS/cfdm?color=2d8659)](https://github.com/NCAS-CMS/cfdm/blob/master/LICENSE)
+[![Conda](https://img.shields.io/conda/pn/ncas/cfdm?color=2d8659)](https://ncas-cms.github.io/cfdm/installation.html#operating-systems) [![Website](https://img.shields.io/website?color=2d8659&down_message=online&label=documentation&up_message=online&url=https%3A%2F%2Fncas-cms.github.io%2Fcfdm%2F)](https://ncas-cms.github.io/cfdm/index.html) [![GitHub](https://img.shields.io/github/license/NCAS-CMS/cfdm?color=2d8659)](https://github.com/NCAS-CMS/cfdm/blob/main/LICENSE)
 
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/NCAS-CMS/cfdm/Run%20test%20suite?color=006666&label=test%20suite%20workflow)](https://github.com/NCAS-CMS/cfdm/actions) [![Codecov](https://img.shields.io/codecov/c/github/NCAS-CMS/cfdm?color=006666)](https://codecov.io/gh/NCAS-CMS/cfdm)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -150,7 +150,7 @@
 * Push recent commits using
 
   ```bash
-  git push origin master
+  git push origin main
   ```
   
 * Tag the release (optional - if you don't do it here then you must do

--- a/cfdm/data/subarray/abstract/subsampledsubarray.py
+++ b/cfdm/data/subarray/abstract/subsampledsubarray.py
@@ -106,7 +106,7 @@ class SubsampledSubarray(Subarray):
                 array.
 
             interpolation_description: `str`, optional
-                A complete description of the non-standardised 
+                A complete description of the non-standardised
                 interpolation method.
 
             source: optional

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ coverage:
         threshold: "0%"
         base: auto
         branches: 
-          - master
+          - main
         if_no_uploads: success
         if_not_found: success  
         if_ci_failed: error
@@ -24,7 +24,7 @@ coverage:
         threshold: "10%"
         base: auto
         branches:
-          - master
+          - main
         if_no_uploads: success
         if_not_found: success
         if_ci_failed: error

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -52,13 +52,19 @@ Pull requests should follow on from a discussion in the issue tracker
 
 Fork the cfdm GitHub repository (https://github.com/NCAS-CMS/cfdm).
 
+..  note::
+    The cfdm GitHub repository uses ``main`` as the name of its
+    default branch, so you must refer to ``main`` when you need to
+    reference the default branch. It is useful to use this as the
+    name of the default branch on your fork, if you use one, too.
+
 Clone your fork locally and create a branch:
 
 .. code-block:: console
 	  
     $ git clone git@github.com:<YOUR GITHUB USERNAME>/cfdm.git
     $ cd cfdm
-    $ git checkout -b <your-bugfix-feature-branch-name master>
+    $ git checkout -b <your-bugfix-feature-branch-name main>
 
 Break your edits up into reasonably-sized commits, each representing
 a single logical change:
@@ -87,7 +93,7 @@ Add your name to the list of contributors list at
 
 Finally, make sure all commits have been pushed to the remote copy of
 your fork and submit the pull request via the GitHub website, to the
-``master`` branch of the ``NCAS-CMS/cfdm`` repository. Make sure to
+``main`` branch of the ``NCAS-CMS/cfdm`` repository. Make sure to
 reference the original issue in the pull request's description.
 
 Note that you can create the pull request while you're working on


### PR DESCRIPTION
Convert references to `master` to the updated name, `main`, towards #230 in configuration files and documentation, etc. Note the documentation is in the process of re-building from the `main` branch, so is down temporarily, but will go back up once that is done (if not, I'll sort it ASAP!).

No need for a review as these are trivial and non-controversial conversions.