### PR TITLE
`get_filename` methods on all `Array` classes.

### DIFF
--- a/cfdm/data/abstract/compressedarray.py
+++ b/cfdm/data/abstract/compressedarray.py
@@ -400,6 +400,28 @@ class CompressedArray(Array):
         """
         return {"data": self.source().copy()}
 
+    def get_filenames(self):
+        """Return the names of any files containing the compressed data.
+
+        .. versionadded:: (cfdm) 1.10.0.2
+
+        :Returns:
+
+            `set`
+                The file names in normalised, absolute form. If the
+                data are all in memory then an empty `set` is
+                returned.
+
+        """
+        data = self._get_compressed_Array(None)
+        if data is None:
+            return set()
+
+        try:
+            return data.get_filenames()
+        except AttributeError:
+            return set()
+
     def get_Subarray(self):
         """Return the Subarray class.
 

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -12,7 +12,6 @@ from ..decorators import (
     _inplace_enabled_define_and_cleanup,
     _manage_log_level_via_verbosity,
 )
-from ..functions import abspath
 from ..mixin.container import Container
 from ..mixin.files import Files
 from ..mixin.netcdf import NetCDFHDF5
@@ -2753,15 +2752,16 @@ class Data(Container, NetCDFHDF5, Files, core.Data):
         return True
 
     def get_filenames(self):
-        """Return the name of the file containing the data array.
+        """Return the names of any files containing the data array.
 
         .. seealso:: `original_filenames`
 
         :Returns:
 
             `set`
-                The file name in normalised, absolute form. If the
-                data is are memory then an empty `set` is returned.
+                The file names in normalised, absolute form. If the
+                data are all in memory then an empty `set` is
+                returned.
 
         **Examples**
 
@@ -2781,11 +2781,9 @@ class Data(Container, NetCDFHDF5, Files, core.Data):
             return set()
 
         try:
-            filename = source.get_filename()
+            return source.get_filenames()
         except AttributeError:
             return set()
-        else:
-            return set((abspath(filename),))
 
     def first_element(self):
         """Return the first element of the data as a scalar.

--- a/cfdm/data/mixin/arraymixin.py
+++ b/cfdm/data/mixin/arraymixin.py
@@ -1,5 +1,7 @@
 import numpy
 
+from ...functions import abspath
+
 
 class ArrayMixin:
     """Mixin class for a container of an array.
@@ -136,6 +138,63 @@ class ArrayMixin:
 
         """
         return self._get_component("compression_type", "")
+
+    def get_filename(self, default=AttributeError()):
+        """The name of the file containing the array.
+
+        If there are multiple files then an `AttributeError` is
+        raised.
+
+        .. versionadded:: (cfdm) 1.10.0.2
+
+        :Parameters:
+
+            default: optional
+                Return the value of the *default* parameter if there
+                is no file.
+
+                {{default Exception}}
+
+        :Returns:
+
+            `str`
+                The file name.
+
+        """
+        filenames = self.get_filenames()
+        if len(filenames) == 1:
+            return filenames.pop()
+        elif not filenames:
+            if default is None:
+                return
+
+            return self._default(
+                default, f"{self.__class__.__name__} has no file"
+            )
+        else:
+            return self._default(
+                default, f"{self.__class__.__name__} has multiple files"
+            )
+
+    def get_filenames(self):
+        """Return the names of any files containing the data array.
+
+        .. versionadded:: (cfdm) 1.10.0.2
+
+        :Returns:
+
+            `set`
+                The file names in normalised, absolute form. If the
+                data are all in memory then an empty `set` is
+                returned.
+
+        """
+        try:
+            filename = self._get_component("filename")
+        except ValueError:
+            return set()
+        else:
+            return set((abspath(filename),))
 
     @classmethod
     def get_subspace(cls, array, indices, copy=True):

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -303,7 +303,7 @@ class NetCDFArray(abstract.Array):
         x.__str__() <==> str(x)
 
         """
-        return f"{self.get_filename()}, {self.get_address()}"
+        return f"{self.get_filename(None)}, {self.get_address()}"
 
     def _set_units(self, var):
         """The units and calendar properties.
@@ -400,7 +400,7 @@ class NetCDFArray(abstract.Array):
         if pointer is None:
             pointer = self.get_varid()
 
-        return (self.get_filename(), pointer)
+        return (self.get_filename(None), pointer)
 
     @property
     def shape(self):
@@ -433,23 +433,23 @@ class NetCDFArray(abstract.Array):
 
         return address
 
-    def get_filename(self):
-        """The name of the netCDF file containing the array.
-
-        .. versionadded:: (cfdm) 1.7.0
-
-        :Returns:
-
-            `str` or `None`
-                The filename, or `None` if there isn't one.
-
-        **Examples**
-
-        >>> a.get_filename()
-        'file.nc'
-
-        """
-        return self._get_component("filename", None)
+    #    def get_filename(self):
+    #        """The name of the netCDF file containing the array.
+    #
+    #        .. versionadded:: (cfdm) 1.7.0
+    #
+    #        :Returns:
+    #
+    #            `str` or `None`
+    #                The filename, or `None` if there isn't one.
+    #
+    #        **Examples**
+    #
+    #        >>> a.get_filename()
+    #        'file.nc'
+    #
+    #        """
+    #        return self._get_component("filename", None)
 
     def get_group(self):
         """The netCDF4 group structure of the netCDF variable.
@@ -551,9 +551,9 @@ class NetCDFArray(abstract.Array):
 
         """
         try:
-            return netCDF4.Dataset(self.get_filename(), "r")
+            return netCDF4.Dataset(self.get_filename(None), "r")
         except RuntimeError as error:
-            raise RuntimeError(f"{error}: {self.get_filename()}")
+            raise RuntimeError(f"{error}: {self.get_filename(None)}")
 
     def to_memory(self):
         """Bring data on disk into memory.

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -433,24 +433,6 @@ class NetCDFArray(abstract.Array):
 
         return address
 
-    #    def get_filename(self):
-    #        """The name of the netCDF file containing the array.
-    #
-    #        .. versionadded:: (cfdm) 1.7.0
-    #
-    #        :Returns:
-    #
-    #            `str` or `None`
-    #                The filename, or `None` if there isn't one.
-    #
-    #        **Examples**
-    #
-    #        >>> a.get_filename()
-    #        'file.nc'
-    #
-    #        """
-    #        return self._get_component("filename", None)
-
     def get_group(self):
         """The netCDF4 group structure of the netCDF variable.
 

--- a/cfdm/data/subarray/abstract/subarray.py
+++ b/cfdm/data/subarray/abstract/subarray.py
@@ -271,3 +271,21 @@ class Subarray(Array):
             raise ValueError("No compressed dimensions have been defined")
 
         return c.copy()
+
+    def get_filenames(self):
+        """Return the names of any files containing the data.
+
+        .. versionadded:: (cfdm) 1.10.0.2
+
+        :Returns:
+
+            `set`
+                The file names in normalised, absolute form. If the
+                data are all in memory then an empty `set` is
+                returned.
+
+        """
+        try:
+            return self.data.get_filenames()
+        except AttributeError:
+            return set()

--- a/cfdm/data/subarray/abstract/subsampledsubarray.py
+++ b/cfdm/data/subarray/abstract/subsampledsubarray.py
@@ -614,6 +614,34 @@ class SubsampledSubarray(Subarray):
         """
         return self._get_component("subarea_indices")
 
+    def get_filenames(self):
+        """Return the names of any files containing the data.
+
+        Includes the names of files that contain any parameters and
+        dependent tie points.
+
+        .. versionadded:: (cfdm) 1.10.0.2
+
+        :Returns:
+
+            `set`
+                The file names in normalised, absolute form. If the
+                data are all in memory then an empty `set` is
+                returned.
+
+        """
+        filenames = super().get_filenames()
+
+        for x in tuple(self.parameters.values()) + tuple(
+            self.dependent_tie_points.values()
+        ):
+            try:
+                filenames.update(x.get_filenames())
+            except AttributeError:
+                pass
+
+        return filenames
+
     def get_interpolation_description(self, default=ValueError()):
         """Get a non-standardised interpolation method description.
 

--- a/cfdm/test/test_LinearSubarray.py
+++ b/cfdm/test/test_LinearSubarray.py
@@ -32,6 +32,23 @@ class LinearSubarrayTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             x.compressed_dimensions()
 
+    def test_LinearSubarray_get_filename(self):
+        """Test LinearSubarray.get_filename."""
+        x = cfdm.LinearSubarray(
+            data=123, parameters={}, dependent_tie_points={}
+        )
+        self.assertIsNone(x.get_filename(None))
+
+        with self.assertRaises(AttributeError):
+            x.get_filename()
+
+    def test_LinearSubarray_get_filenames(self):
+        """Test LinearSubarray.get_filenames."""
+        x = cfdm.LinearSubarray(
+            data=123, parameters={}, dependent_tie_points={}
+        )
+        self.assertEqual(x.get_filenames(), set())
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cfdm/test/test_NumpyArray.py
+++ b/cfdm/test/test_NumpyArray.py
@@ -43,6 +43,14 @@ class NumpyArrayTest(unittest.TestCase):
         b = numpy.array(x)
         self.assertTrue((b == a).all())
 
+    def test_NumpyArray_get_filename(self):
+        """Test NumpyArray.get_filename."""
+        x = cfdm.NumpyArray()
+        self.assertIsNone(x.get_filename(None))
+
+        with self.assertRaises(AttributeError):
+            x.get_filename()
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cfdm/test/test_SubsampledArray.py
+++ b/cfdm/test/test_SubsampledArray.py
@@ -100,6 +100,18 @@ class SubsampledArrayTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             c.compressed_dimensions()
 
+    def test_SubsampledArray_get_filename(self):
+        """Test SubsampledArray.get_filename."""
+        x = self.coords
+        self.assertIsNone(x.get_filename(None))
+
+        with self.assertRaises(AttributeError):
+            x.get_filename()
+
+    def test_SubsampledArray_get_filenames(self):
+        """Test `SubsampledArray.get_filenames."""
+        self.assertEqual(self.coords.get_filenames(), set())
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cfdm/test/test_subsampling.py
+++ b/cfdm/test/test_subsampling.py
@@ -29,8 +29,8 @@ def _remove_tmpfiles():
 atexit.register(_remove_tmpfiles)
 
 
-class GatheredTest(unittest.TestCase):
-    """Test management of constructs with underlying gathered arrays."""
+class SubsamplingTest(unittest.TestCase):
+    """Test constructs with underlying subsampled arrays."""
 
     biquadratic = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "subsampled_2.nc"
@@ -240,6 +240,13 @@ class GatheredTest(unittest.TestCase):
         # Check that we can't uncompress the data
         with self.assertRaises(ValueError):
             a_2d.array
+
+    def test_SubsampledArray_get_filenames(self):
+        """Test SubsampledArray.get_filenames."""
+        f = cfdm.read(self.linear)
+        q = f[0]
+        lat = q.construct("latitude").data
+        self.assertEqual(lat.get_filenames(), set((self.linear,)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Passes `get_filename` down to all `Array` objects, mainly so that it accessible to cf-python's need for deep navel-gazing.