### PR TITLE
Improve source docstrings in `__init__` methods

### DIFF
--- a/cfdm/auxiliarycoordinate.py
+++ b/cfdm/auxiliarycoordinate.py
@@ -71,11 +71,7 @@ class AuxiliaryCoordinate(
 
             {{init interior_ring: `InteriorRing`, optional}}
 
-            source: optional
-                Initialise the properties, data and bounds from those of
-                *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/bounds.py
+++ b/cfdm/bounds.py
@@ -61,10 +61,7 @@ class Bounds(
 
             {{init data: data_like, optional}}
 
-            source: optional
-                Initialise the properties and data from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/cellmeasure.py
+++ b/cfdm/cellmeasure.py
@@ -58,8 +58,7 @@ class CellMeasure(
 
             measure: `str`, optional
                 Set the measure that indicates the metric given by
-                the data array. Ignored if the *source* parameter is
-                set.
+                the data array.
 
                 The measure may also be set after initialisation with
                 the `set_measure` method.
@@ -74,11 +73,7 @@ class CellMeasure(
 
             {{init data: data_like, optional}}
 
-            source: optional
-                Initialise the measure, properties and data from those
-                of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/coordinatereference.py
+++ b/cfdm/coordinatereference.py
@@ -90,7 +90,7 @@ class CoordinateReference(
             coordinates: sequence of `str`, optional
                 Identify the related dimension and auxiliary
                 coordinate constructs by their construct
-                identifiers. Ignored if the *source* parameter is set.
+                identifiers.
 
                 The coordinates may also be set after initialisation
                 with the `set_coordinates` and `set_coordinate`
@@ -104,25 +104,20 @@ class CoordinateReference(
 
             datum: `Datum`, optional
                 Set the datum component of the coordinate reference
-                construct. Ignored if the *source* parameter is set.
+                construct.
 
                 The datum may also be set after initialisation with
                 the `set_datum` method.
 
             coordinate_conversion: `CoordinateConversion`, optional
                 Set the coordinate conversion component of the
-                coordinate reference construct. Ignored if the
-                *source* parameter is set.
+                coordinate reference construct.
 
                 The coordinate conversion may also be set after
                 initialisation with the `set_coordinate_conversion`
                 method.
 
-            source: optional
-                Initialise the coordinates, datum and coordinate
-                conversion from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/abstract/container.py
+++ b/cfdm/core/abstract/container.py
@@ -25,10 +25,7 @@ class Container(metaclass=DocstringRewriteMeta):
 
         :Parameters:
 
-            source: optional
-                Initialise the components from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/abstract/parameters.py
+++ b/cfdm/core/abstract/parameters.py
@@ -16,8 +16,7 @@ class Parameters(Container):
 
             parameters: `dict`, optional
                Set parameters. The dictionary keys are parameter
-               names, with corresponding values. Ignored if the
-               *source* parameter is set.
+               names, with corresponding values.
 
                Parameters may also be set after initialisation with
                the `set_parameters` and `set_parameter` methods.
@@ -25,10 +24,7 @@ class Parameters(Container):
                *Parameter example:*
                  ``parameters={'earth_radius': 6371007.}``
 
-            source: optional
-                Initialise the parameters from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/abstract/parametersdomainancillaries.py
+++ b/cfdm/core/abstract/parametersdomainancillaries.py
@@ -17,8 +17,7 @@ class ParametersDomainAncillaries(Parameters):
 
             parameters: `dict`, optional
                Set parameters. The dictionary keys are term names,
-               with corresponding parameter values. Ignored if the
-               *source* parameter is set.
+               with corresponding parameter values.
 
                Parameters may also be set after initialisation with
                the `set_parameters` and `set_parameter` methods.
@@ -29,8 +28,7 @@ class ParametersDomainAncillaries(Parameters):
             domain_ancillaries: `dict`, optional
                Set references to domain ancillary constructs. The
                dictionary keys are term names, with corresponding
-               domain ancillary construct keys. Ignored if the
-               *source* parameter is set.
+               domain ancillary construct keys.
 
                Domain ancillaries may also be set after initialisation
                with the `set_domain_ancillaries` and
@@ -39,11 +37,7 @@ class ParametersDomainAncillaries(Parameters):
                *Parameter example:*
                  ``domain_ancillaries={'orog': 'domainancillary2'}``
 
-            source: optional
-                Initialise the parameters and domain ancillary terms
-                from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/abstract/properties.py
+++ b/cfdm/core/abstract/properties.py
@@ -19,10 +19,7 @@ class Properties(Container):
                 *Parameter example:*
                    ``properties={'standard_name': 'altitude'}``
 
-            source: optional
-                Initialise the properties from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/abstract/propertiesdata.py
+++ b/cfdm/core/abstract/propertiesdata.py
@@ -40,10 +40,7 @@ class PropertiesData(Properties):
 
             {{init data: data_like, optional}}
 
-            source: optional
-                Initialise the properties and data from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/abstract/propertiesdatabounds.py
+++ b/cfdm/core/abstract/propertiesdatabounds.py
@@ -43,11 +43,7 @@ class PropertiesDataBounds(PropertiesData):
 
             {{init interior_ring: `InteriorRing`, optional}}
 
-            source: optional
-                Initialise the properties, geometry type, data, bounds
-                and interior ring from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/bounds.py
+++ b/cfdm/core/bounds.py
@@ -38,11 +38,7 @@ class Bounds(abstract.PropertiesData):
 
             {{init data: data_like, optional}}
 
-            source: optional
-                Initialise the properties and data from those of *source*.
-                respectively.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/cellmeasure.py
+++ b/cfdm/core/cellmeasure.py
@@ -41,8 +41,7 @@ class CellMeasure(abstract.PropertiesData):
 
             measure: `str`, optional
                 Set the measure that indicates the metric given by
-                the data array. Ignored if the *source* parameter is
-                set.
+                the data array.
 
                 The measure may also be set after initialisation with
                 the `set_measure` method.
@@ -57,11 +56,7 @@ class CellMeasure(abstract.PropertiesData):
 
             {{init data: data_like, optional}}
 
-            source: optional
-                Initialise the measure, properties and data from those
-                of source.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/cellmethod.py
+++ b/cfdm/core/cellmethod.py
@@ -56,7 +56,7 @@ class CellMethod(abstract.Container):
             method: `str`, optional
                 Set the axes of the cell method construct. Either one or
                 more domain axis construct identifiers or standard
-                names. Ignored if the *source* parameter is set.
+                names.
 
                 The method may also be set after initialisation with the
                 `set_method` method.
@@ -66,8 +66,7 @@ class CellMethod(abstract.Container):
 
             qualifiers: `dict`, optional
                 Set descriptive qualifiers. The dictionary keys are
-                qualifier names, with corresponding values. Ignored if the
-                *source* parameter is set.
+                qualifier names, with corresponding values.
 
                 Qualifiers may also be set after initialisation with the
                 `qualifiers` and `set_qualifier` methods.
@@ -78,11 +77,7 @@ class CellMethod(abstract.Container):
                 *Parameter example:*
                   ``qualifiers={'where': 'sea', ''over': 'ice'}``
 
-            source: optional
-                Initialise the axes, method and qualifiers from those of
-                *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/constructs.py
+++ b/cfdm/core/constructs.py
@@ -97,9 +97,7 @@ class Constructs(abstract.Container):
                 *Parameter example:*
                   ``cell_method='cellmethod'``
 
-            source: optional
-                Initialise the construct keys and contained metadata
-                constructs from those of *source*.
+            {{init source: optional}}
 
             copy: `bool`, optional
                 If True (the default) then deep copy metadata constructs

--- a/cfdm/core/coordinatereference.py
+++ b/cfdm/core/coordinatereference.py
@@ -74,7 +74,7 @@ class CoordinateReference(abstract.Container):
             coordinates: sequence of `str`, optional
                 Identify the related dimension and auxiliary
                 coordinate constructs by their construct
-                identifiers. Ignored if the *source* parameter is set.
+                identifiers.
 
                 The coordinates may also be set after initialisation
                 with the `set_coordinates` and `set_coordinate`
@@ -88,25 +88,20 @@ class CoordinateReference(abstract.Container):
 
             datum: `Datum`, optional
                 Set the datum component of the coordinate reference
-                construct. Ignored if the *source* parameter is set.
+                construct.
 
                 The datum may also be set after initialisation with
                 the `set_datum` method.
 
             coordinate_conversion: `CoordinateConversion`, optional
                 Set the coordinate conversion component of the
-                coordinate reference construct. Ignored if the
-                *source* parameter is set.
+                coordinate reference construct.
 
                 The coordinate conversion may also be set after
                 initialisation with the `set_coordinate_conversion`
                 method.
 
-            source: optional
-                Initialise the coordinates, datum and coordinate
-                conversion from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/data/abstract/array.py
+++ b/cfdm/core/data/abstract/array.py
@@ -22,9 +22,9 @@ class Array(Container):
 
         :Parameters:
 
-            kwargs: optional
-                Named parameters and their values that define the
-                array.
+            {{init source: optional}}
+
+            {{init copy: `bool`, optional}}
 
         """
         super().__init__(source=source, copy=copy)

--- a/cfdm/core/data/data.py
+++ b/cfdm/core/data/data.py
@@ -37,8 +37,6 @@ class Data(abstract.Container):
                 ``{{package}}.{{class}}(array)`` is equivalent to
                 ``{{package}}.{{class}}(source=array.__data__())``.
 
-                Ignored if the *source* parameter is set.
-
             array: `numpy` array_like, optional
                 The array of values.
 
@@ -46,11 +44,8 @@ class Data(abstract.Container):
                 then ``{{package}}.{{class}}(array)`` is equivalent to
                 ``{{package}}.{{class}}(source=array)``.
 
-                Ignored if the *source* parameter is set.
-
             units: `str`, optional
-                The physical units of the data. Ignored if the
-                *source* parameter is set.
+                The physical units of the data.
 
                 The units may also be set after initialisation with
                 the `set_units` method.
@@ -62,8 +57,7 @@ class Data(abstract.Container):
                   ``units='days since 2018-12-01'``
 
             calendar: `str`, optional
-                The calendar for reference time units. Ignored if the
-                *source* parameter is set.
+                The calendar for reference time units.
 
                 The calendar may also be set after initialisation with
                 the `set_calendar` method.
@@ -75,8 +69,7 @@ class Data(abstract.Container):
                 The fill value of the data. By default, or if set to
                 `None`, the `numpy` fill value appropriate to the
                 array's data type will be used (see
-                `numpy.ma.default_fill_value`). Ignored if the
-                *source* parameter is set.
+                `numpy.ma.default_fill_value`).
 
                 The fill value may also be set after initialisation
                 with the `set_fill_value` method.
@@ -84,9 +77,7 @@ class Data(abstract.Container):
                 *Parameter example:*
                   ``fill_value=-999.``
 
-            source: *optional*
-                Initialise the data, units, calendar and fill value
-                from those of *source*.
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/data/numpyarray.py
+++ b/cfdm/core/data/numpyarray.py
@@ -18,6 +18,10 @@ class NumpyArray(abstract.Array):
             array: `numpy.ndarray`
                 The numpy array.
 
+            {{init source: optional}}
+
+            {{init copy: `bool`, optional}}
+
         """
         super().__init__(source=source, copy=copy)
 

--- a/cfdm/core/docstring/docstring.py
+++ b/cfdm/core/docstring/docstring.py
@@ -64,15 +64,13 @@ _docstring_substitution_definitions = {
     # init properties
     "{{init properties: `dict`, optional}}": """properties: `dict`, optional
                 Set descriptive properties. The dictionary keys are
-                property names, with corresponding values. Ignored if
-                the *source* parameter is set.
+                property names, with corresponding values.
 
                 Properties may also be set after initialisation with
                 the `set_properties` and `set_property` methods.""",
     # init data
     "{{init data: data_like, optional}}": """data: data_like, optional
-                Set the data. Ignored if the *source* parameter is
-                set.
+                Set the data.
 
                 {{data_like}}
 
@@ -80,15 +78,13 @@ _docstring_substitution_definitions = {
                 `set_data` method.""",
     # init bounds
     "{{init bounds: `Bounds`, optional}}": """bounds: `Bounds`, optional
-                Set the bounds array. Ignored if the *source*
-                parameter is set.
+                Set the bounds array.
 
                 The bounds array may also be set after initialisation
                 with the `set_bounds` method.""",
     # init geometry
     "{{init geometry: `str`, optional}}": """geometry: `str`, optional
-                Set the geometry type. Ignored if the *source*
-                parameter is set.
+                Set the geometry type.
 
                 The geometry type may also be set after initialisation
                 with the `set_geometry` method.
@@ -97,8 +93,7 @@ _docstring_substitution_definitions = {
                   ``geometry='polygon'``""",
     # init interior_ring
     "{{init interior_ring: `InteriorRing`, optional}}": """interior_ring: `InteriorRing`, optional
-                Set the interior ring variable. Ignored if the
-                *source* parameter is set.
+                Set the interior ring variable.
 
                 The interior ring variable may also be set after
                 initialisation with the `set_interior_ring` method.""",
@@ -108,7 +103,15 @@ _docstring_substitution_definitions = {
                 to initialisation. If False arguments are not deep
                 copied.""",
     # init source
-    "{{init source}}": """Note that if *source* is a `{{class}}` instance then
+    "{{init source: optional}}": """source: optional
+                Initialise the `{{class}}` instance from the *source*
+                object. All other parameters, apart from *copy*, are
+                ignored and their values are instead inferred from
+                *source* using the `{{class}}` API. Any parameters
+                that can not be retrieved from *source* are assumed to
+                have their default value.
+
+                Note that if *source* is a `{{class}}` instance then
                 ``{{package}}.{{class}}(source=source)`` is equivalent
                 to ``source.copy()``.""",
     # data_like

--- a/cfdm/core/docstring/docstring.py
+++ b/cfdm/core/docstring/docstring.py
@@ -104,16 +104,18 @@ _docstring_substitution_definitions = {
                 parameters are not deep copied.""",
     # init source
     "{{init source: optional}}": """source: optional
-                Initialise the `{{class}}` instance from the *source*
-                object. All other parameters, apart from *copy*, are
-                ignored and their values are instead inferred from
-                *source* using the `{{class}}` API. Any parameters
-                that can not be retrieved from *source* are assumed to
-                have their default value.
+                Convert *source*, which can be any type of object, to
+                a `{{class}}` instance.
 
-                Note that if *source* is a `{{class}}` instance then
-                ``{{package}}.{{class}}(source=source)`` is equivalent
-                to ``source.copy()``.""",
+                All other parameters, apart from *copy*, are ignored
+                and their values are instead inferred from *source* by
+                assuming that it has the `{{class}}` API. Any
+                parameters that can not be retrieved from *source* in
+                this way are assumed to have their default value.
+
+                Note that if ``x`` is aslo a `{{class}}` instance then
+                ``{{package}}.{{class}}(source=x)`` is equivalent to
+                ``x.copy()``.""",
     # data_like
     "{{data_like}}": """A data_like object is any object that can be converted
                 to a `Data` object, i.e. `numpy` array_like objects,

--- a/cfdm/core/docstring/docstring.py
+++ b/cfdm/core/docstring/docstring.py
@@ -113,7 +113,7 @@ _docstring_substitution_definitions = {
                 parameters that can not be retrieved from *source* in
                 this way are assumed to have their default value.
 
-                Note that if ``x`` is aslo a `{{class}}` instance then
+                Note that if ``x`` is also a `{{class}}` instance then
                 ``{{package}}.{{class}}(source=x)`` is equivalent to
                 ``x.copy()``.""",
     # data_like

--- a/cfdm/core/docstring/docstring.py
+++ b/cfdm/core/docstring/docstring.py
@@ -99,9 +99,9 @@ _docstring_substitution_definitions = {
                 initialisation with the `set_interior_ring` method.""",
     # init copy
     "{{init copy: `bool`, optional}}": """copy: `bool`, optional
-                If True (the default) deep copy input parameters prior
-                to initialisation. If False arguments are not deep
-                copied.""",
+                If True (the default) then deep copy the input
+                parameters prior to initialisation. By default the
+                parameters are not deep copied.""",
     # init source
     "{{init source: optional}}": """source: optional
                 Initialise the `{{class}}` instance from the *source*

--- a/cfdm/core/domain.py
+++ b/cfdm/core/domain.py
@@ -47,11 +47,7 @@ class Domain(mixin.FieldDomain, abstract.Properties):
             *Parameter example:*
                ``properties={'long_name': 'Domain for model'}``
 
-            source: optional
-                Initialise the metadata constructs from those of
-                *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
                 A new domain may also be instantiated with the
                 `fromconstructs` class method.

--- a/cfdm/core/domainaxis.py
+++ b/cfdm/core/domainaxis.py
@@ -31,10 +31,7 @@ class DomainAxis(abstract.Container):
                 The size may also be set after initialisation with the
                 `set_size` method.
 
-            source:
-                Initialise the size from that of source.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/core/field.py
+++ b/cfdm/core/field.py
@@ -71,11 +71,7 @@ class Field(mixin.FieldDomain, abstract.PropertiesData):
                 *Parameter example:*
                    ``properties={'standard_name': 'air_temperature'}``
 
-            source: optional
-                Initialise the properties, data and metadata
-                constructs from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/count.py
+++ b/cfdm/count.py
@@ -60,11 +60,7 @@ class Count(
 
                 {{data_like}}
 
-            source: optional
-                Initialise the properties and data from those of
-                *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/data/abstract/compressedarray.py
+++ b/cfdm/data/abstract/compressedarray.py
@@ -84,10 +84,7 @@ class CompressedArray(Array):
             compressed_dimension: Deprecated at version 1.10.0.0
                 Use the *compressed_dimensions* parameter instead.
 
-            source: optional
-                Initialise the array from the given object.
-
-                {{init source}}
+            {{init source: optional}}
 
                 .. versionadded:: (cfdm) 1.10.0.0
 

--- a/cfdm/data/abstract/raggedarray.py
+++ b/cfdm/data/abstract/raggedarray.py
@@ -76,7 +76,7 @@ class RaggedArray(CompressedArray):
 
             {{init source: optional}}
 
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
         """
         if count_variable is not None:

--- a/cfdm/data/abstract/raggedarray.py
+++ b/cfdm/data/abstract/raggedarray.py
@@ -74,10 +74,7 @@ class RaggedArray(CompressedArray):
                 corresponding to a CF-netCDF count variable, if
                 required by the decompression method.
 
-            source: optional
-                Initialise the array from the given object.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{deep copy}}
 

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -121,7 +121,7 @@ class Data(Container, NetCDFHDF5, Files, core.Data):
 
             {{init source: optional}}
 
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
             kwargs: ignored
                 Not used. Present to facilitate subclassing.

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -49,8 +49,6 @@ class Data(Container, NetCDFHDF5, Files, core.Data):
 
                 {{data_like}}
 
-                Ignored if the *source* parameter is set.
-
                 *Parameter example:*
                   ``array=[34.6]``
 
@@ -61,8 +59,7 @@ class Data(Container, NetCDFHDF5, Files, core.Data):
                   ``array=numpy.ma.arange(10).reshape(2, 1, 5)``
 
             units: `str`, optional
-                The physical units of the data. Ignored if the *source*
-                parameter is set.
+                The physical units of the data.
 
                 The units may also be set after initialisation with the
                 `set_units` method.
@@ -74,8 +71,7 @@ class Data(Container, NetCDFHDF5, Files, core.Data):
                   ``units='days since 2018-12-01'``
 
             calendar: `str`, optional
-                The calendar for reference time units. Ignored if the
-                *source* parameter is set.
+                The calendar for reference time units.
 
                 The calendar may also be set after initialisation with the
                 `set_calendar` method.
@@ -85,10 +81,9 @@ class Data(Container, NetCDFHDF5, Files, core.Data):
 
             fill_value: optional
                 The fill value of the data. By default, or if set to
-                `None`, the `numpy` fill value appropriate to the array's
-                data type will be used (see
-                `numpy.ma.default_fill_value`). Ignored if the *source*
-                parameter is set.
+                `None`, the `numpy` fill value appropriate to the
+                array's data type will be used (see
+                `numpy.ma.default_fill_value`).
 
                 The fill value may also be set after initialisation with
                 the `set_fill_value` method.
@@ -124,11 +119,7 @@ class Data(Container, NetCDFHDF5, Files, core.Data):
                 This mask will applied in addition to any mask already
                 defined by the *array* parameter.
 
-            source: optional
-                Initialise the array, units, calendar and fill value
-                from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{deep copy}}
 

--- a/cfdm/data/gatheredarray.py
+++ b/cfdm/data/gatheredarray.py
@@ -83,7 +83,7 @@ class GatheredArray(CompressedArray):
 
                 .. versionadded:: (cfdm) 1.10.0.0
 
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
                 .. versionadded:: (cfdm) 1.10.0.0
 

--- a/cfdm/data/gatheredarray.py
+++ b/cfdm/data/gatheredarray.py
@@ -79,10 +79,7 @@ class GatheredArray(CompressedArray):
             compressed_dimension: deprecated at version 1.10.0.0
                 Use the *compressed_dimensions* parameter instead.
 
-            source: optional
-                Initialise the array from the given object.
-
-                {{init source}}
+            {{init source: optional}}
 
                 .. versionadded:: (cfdm) 1.10.0.0
 

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -107,10 +107,7 @@ class NetCDFArray(abstract.Array):
 
                 .. versionadded:: (cfdm) 1.10.0.1
 
-            source: optional
-                Initialise the array from the given object.
-
-                {{init source}}
+            {{init source: optional}}
 
                 .. versionadded:: (cfdm) 1.10.0.0
 

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -111,7 +111,7 @@ class NetCDFArray(abstract.Array):
 
                 .. versionadded:: (cfdm) 1.10.0.0
 
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
                 .. versionadded:: (cfdm) 1.10.0.0
 

--- a/cfdm/data/raggedcontiguousarray.py
+++ b/cfdm/data/raggedcontiguousarray.py
@@ -49,10 +49,7 @@ class RaggedContiguousArray(RaggedArray):
                 The count variable required to uncompress the data,
                 corresponding to a CF-netCDF count variable.
 
-            source: optional
-                Initialise the array from the given object.
-
-                {{init source}}
+            {{init source: optional}}
 
                 .. versionadded:: (cfdm) 1.10.0.0
 

--- a/cfdm/data/raggedcontiguousarray.py
+++ b/cfdm/data/raggedcontiguousarray.py
@@ -53,7 +53,7 @@ class RaggedContiguousArray(RaggedArray):
 
                 .. versionadded:: (cfdm) 1.10.0.0
 
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
                 .. versionadded:: (cfdm) 1.10.0.0
 

--- a/cfdm/data/raggedindexedarray.py
+++ b/cfdm/data/raggedindexedarray.py
@@ -54,7 +54,7 @@ class RaggedIndexedArray(RaggedArray):
 
                 .. versionadded:: (cfdm) 1.10.0.0
 
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
                 .. versionadded:: (cfdm) 1.10.0.0
 

--- a/cfdm/data/raggedindexedarray.py
+++ b/cfdm/data/raggedindexedarray.py
@@ -50,10 +50,7 @@ class RaggedIndexedArray(RaggedArray):
                 The index variable required to uncompress the data,
                 corresponding to a CF-netCDF index variable.
 
-            source: optional
-                Initialise the array from the given object.
-
-                {{init source}}
+            {{init source: optional}}
 
                 .. versionadded:: (cfdm) 1.10.0.0
 

--- a/cfdm/data/raggedindexedcontiguousarray.py
+++ b/cfdm/data/raggedindexedcontiguousarray.py
@@ -58,10 +58,7 @@ class RaggedIndexedContiguousArray(RaggedArray):
                 The index variable required to uncompress the data,
                 corresponding to a CF-netCDF CF-netCDF index variable.
 
-            source: optional
-                Initialise the array from the given object.
-
-                {{init source}}
+            {{init source: optional}}
 
                 .. versionadded:: (cfdm) 1.10.0.0
 

--- a/cfdm/data/raggedindexedcontiguousarray.py
+++ b/cfdm/data/raggedindexedcontiguousarray.py
@@ -62,7 +62,7 @@ class RaggedIndexedContiguousArray(RaggedArray):
 
                 .. versionadded:: (cfdm) 1.10.0.0
 
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
                 .. versionadded:: (cfdm) 1.10.0.0
 

--- a/cfdm/data/subarray/abstract/subarray.py
+++ b/cfdm/data/subarray/abstract/subarray.py
@@ -63,7 +63,7 @@ class Subarray(Array):
 
             {{init source: optional}}
 
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
             context_manager: function, optional
                 A context manager that provides a runtime context for

--- a/cfdm/data/subarray/abstract/subarray.py
+++ b/cfdm/data/subarray/abstract/subarray.py
@@ -61,10 +61,7 @@ class Subarray(Array):
                 *Parameter example:*
                   ``{0: (0,), 2: (2,)}``
 
-            source: optional
-                Initialise the subarray from the given object.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{deep copy}}
 

--- a/cfdm/data/subarray/abstract/subsampledsubarray.py
+++ b/cfdm/data/subarray/abstract/subsampledsubarray.py
@@ -111,7 +111,7 @@ class SubsampledSubarray(Subarray):
 
             {{init source: optional}}
 
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
             context_manager: function, optional
                 A context manager that provides a runtime context for

--- a/cfdm/data/subarray/abstract/subsampledsubarray.py
+++ b/cfdm/data/subarray/abstract/subsampledsubarray.py
@@ -109,10 +109,7 @@ class SubsampledSubarray(Subarray):
                 A complete description of the non-standardised
                 interpolation method.
 
-            source: optional
-                Initialise the subarray from the given object.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{deep copy}}
 

--- a/cfdm/data/subarray/gatheredsubarray.py
+++ b/cfdm/data/subarray/gatheredsubarray.py
@@ -64,7 +64,7 @@ class GatheredSubarray(Subarray):
 
             {{init source: optional}}
 
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
             context_manager: function, optional
                 A context manager that provides a runtime context for

--- a/cfdm/data/subarray/gatheredsubarray.py
+++ b/cfdm/data/subarray/gatheredsubarray.py
@@ -62,10 +62,7 @@ class GatheredSubarray(Subarray):
                 Indices of the uncompressed subarray for the
                 compressed data.
 
-            source: optional
-                Initialise the subarray from the given object.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{deep copy}}
 

--- a/cfdm/data/subsampledarray.py
+++ b/cfdm/data/subsampledarray.py
@@ -243,10 +243,7 @@ class SubsampledArray(CompressedArray):
                 *Parameter example:*
                   ``{'latitude': (2, 0, 1)}``
 
-            source: optional
-                Initialise the array from the given object.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{deep copy}}
 

--- a/cfdm/data/subsampledarray.py
+++ b/cfdm/data/subsampledarray.py
@@ -245,7 +245,7 @@ class SubsampledArray(CompressedArray):
 
             {{init source: optional}}
 
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
         """
         super().__init__(

--- a/cfdm/datum.py
+++ b/cfdm/datum.py
@@ -33,8 +33,7 @@ class Datum(mixin.Parameters, mixin.NetCDFVariable, mixin.Files, core.Datum):
 
             parameters: `dict`, optional
                Set parameters. The dictionary keys are parameter
-               names, with corresponding values. Ignored if the
-               *source* parameter is set.
+               names, with corresponding values.
 
                Parameters may also be set after initialisation with
                the `set_parameters` and `set_parameter` methods.
@@ -42,10 +41,7 @@ class Datum(mixin.Parameters, mixin.NetCDFVariable, mixin.Files, core.Datum):
                *Parameter example:*
                  ``parameters={'earth_radius': 6371007.}``
 
-            source: optional
-                Initialise the parameters from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/dimensioncoordinate.py
+++ b/cfdm/dimensioncoordinate.py
@@ -70,11 +70,7 @@ class DimensionCoordinate(
 
             {{init interior_ring: `InteriorRing`, optional}}
 
-            source: optional
-                Initialise the properties, data and bounds from those of
-                *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/docstring/docstring.py
+++ b/cfdm/docstring/docstring.py
@@ -353,11 +353,6 @@ _docstring_substitution_definitions = {
                 By default, *chunks* is ``-1``, meaning that all
                 non-compressed dimensions in each subarray have the
                 maximum possible size.""",
-    # deep copy
-    "{{deep copy}}": """copy: `bool`, optional
-                If True (the default) then deep copy input
-                parameters prior to initialisation, else they are
-                not (deep) copied.""",
     # clear
     "{{clear: `bool` optional}}": """clear: `bool` optional
                 If True then remove any stored original file

--- a/cfdm/docstring/docstring.py
+++ b/cfdm/docstring/docstring.py
@@ -105,15 +105,7 @@ _docstring_substitution_definitions = {
         collection of original files from all contributing sources.""",
     # ----------------------------------------------------------------
     # Method description substitutions (3 levels of indentataion)
-    # ----------------------------------------------------------------
-    # init properties: `dict`, optional
-    "{{init properties: `dict`, optional}}": """properties: `dict`, optional
-                Set descriptive properties. The dictionary keys are
-                property names, with corresponding values. Ignored if
-                the *source* parameter is set.
-
-                Properties may also be set after initialisation with
-                the `set_properties` and `set_property` methods.""",
+    # ------------------------1----------------------------------------
     # atol: number, optional
     "{{atol: number, optional}}": """atol: number, optional
                 The tolerance on absolute differences between real

--- a/cfdm/domain.py
+++ b/cfdm/domain.py
@@ -87,11 +87,7 @@ class Domain(
                 *Parameter example:*
                    ``properties={'long_name': 'Domain for model'}``
 
-            source: optional
-                Initialise the metadata constructs from those of
-                *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
                 A new domain may also be instantiated with the
                 `fromconstructs` class method.

--- a/cfdm/domainancillary.py
+++ b/cfdm/domainancillary.py
@@ -60,11 +60,7 @@ class DomainAncillary(
 
             {{init interior_ring: `InteriorRing`, optional}}
 
-            source: optional
-                Initialise the properties, data and bounds from those
-                of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/domainaxis.py
+++ b/cfdm/domainaxis.py
@@ -54,10 +54,7 @@ class DomainAxis(
                 *Parameter example:*
                   ``size=192``
 
-            source: optional
-                Initialise the size from that of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/field.py
+++ b/cfdm/field.py
@@ -116,11 +116,7 @@ class Field(
                 *Parameter example:*
                   ``properties={'standard_name': 'air_temperature'}``
 
-            source: optional
-                Initialise the properties, data and metadata constructs
-                from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/fieldancillary.py
+++ b/cfdm/fieldancillary.py
@@ -55,11 +55,7 @@ class FieldAncillary(
 
             {{init data: data_like, optional}}
 
-            source: optional
-                Initialise the properties and data from those of
-                *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/index.py
+++ b/cfdm/index.py
@@ -68,10 +68,7 @@ class Index(
 
             {{init data: data_like, optional}}
 
-            source: optional
-                Initialise the properties and data from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/interiorring.py
+++ b/cfdm/interiorring.py
@@ -58,10 +58,7 @@ class InteriorRing(
 
             {{init data: data_like, optional}}
 
-            source: optional
-                Initialise the properties and data from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/interpolationparameter.py
+++ b/cfdm/interpolationparameter.py
@@ -51,11 +51,7 @@ class InterpolationParameter(
 
             {{init data: data_like, optional}}
 
-            source: optional
-                Initialise the properties and data from those of
-                *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/list.py
+++ b/cfdm/list.py
@@ -43,11 +43,7 @@ class List(
 
             {{init data: data_like, optional}}
 
-            source: optional
-                Initialise the properties and data from those of
-                *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/mixin/files.py
+++ b/cfdm/mixin/files.py
@@ -16,9 +16,7 @@ class Files:
 
         :Parameters:
 
-            source: optional
-                Initialise the original file names from those of
-                *source*.
+            {{init source: optional}}
 
         :Returns:
 

--- a/cfdm/mixin/netcdf.py
+++ b/cfdm/mixin/netcdf.py
@@ -22,9 +22,7 @@ class NetCDF:
 
         :Parameters:
 
-            source: optional
-                Initialise the netCDF components from those of
-                *source*.
+            {{init source: optional}}
 
         :Returns:
 

--- a/cfdm/mixin/propertiesdatabounds.py
+++ b/cfdm/mixin/propertiesdatabounds.py
@@ -39,8 +39,7 @@ class PropertiesDataBounds(PropertiesData):
 
             properties: `dict`, optional
                 Set descriptive properties. The dictionary keys are
-                property names, with corresponding values. Ignored if
-                the *source* parameter is set.
+                property names, with corresponding values.
 
                 Properties may also be set after initialisation with
                 the `properties` and `set_property` methods.
@@ -51,15 +50,13 @@ class PropertiesDataBounds(PropertiesData):
             {{init data: data_like, optional}}
 
             bounds: `Bounds`, optional
-                Set the bounds array. Ignored if the *source*
-                parameter is set.
+                Set the bounds array.
 
                 The bounds array may also be set after initialisation
                 with the `set_bounds` method.
 
             geometry: `str`, optional
-                Set the geometry type. Ignored if the *source*
-                parameter is set.
+                Set the geometry type.
 
                 The geometry type may also be set after initialisation
                 with the `set_geometry` method.
@@ -68,32 +65,26 @@ class PropertiesDataBounds(PropertiesData):
                   ``geometry='polygon'``
 
             interior_ring: `InteriorRing`, optional
-                Set the interior ring variable. Ignored if the
-                *source* parameter is set.
+                Set the interior ring variable.
 
                 The interior ring variable may also be set after
                 initialisation with the `set_interior_ring` method.
 
             node_count: `NodeCount`, optional
                 Set the node count variable for geometry
-                bounds. Ignored if the *source* parameter is set.
+                bounds.
 
                 The node count variable may also be set after
                 initialisation with the `set_node_count` method.
 
             part_node_count: `PartNodeCount`, optional
                 Set the part node count variable for geometry
-                bounds. Ignored if the *source* parameter is set.
+                bounds.
 
                 The part node count variable may also be set after
                 initialisation with the `set_node_count` method.
 
-            source: optional
-                Initialise the properties, geometry type, data,
-                bounds, interior ring variable, node count variable
-                and part node count variable from those of *source*.
-
-                {{init source}}
+            {{init source: optional}}
 
             {{deep copy}}
 

--- a/cfdm/mixin/propertiesdatabounds.py
+++ b/cfdm/mixin/propertiesdatabounds.py
@@ -86,7 +86,7 @@ class PropertiesDataBounds(PropertiesData):
 
             {{init source: optional}}
 
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
         """
         # Initialise properties, data, geometry and interior ring

--- a/cfdm/nodecountproperties.py
+++ b/cfdm/nodecountproperties.py
@@ -28,8 +28,7 @@ class NodeCountProperties(
                   ``properties={'long_name': 'number of nodes for each
                   geometry'}``
 
-            source: optional
-                Initialise the properties from those of *source*.
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/partnodecountproperties.py
+++ b/cfdm/partnodecountproperties.py
@@ -34,8 +34,7 @@ class PartNodeCountProperties(
                   ``properties={'long_name': 'number of obs for this
                   station'}``
 
-            source: optional
-                Initialise the properties from those of *source*.
+            {{init source: optional}}
 
             {{init copy: `bool`, optional}}
 

--- a/cfdm/tiepointindex.py
+++ b/cfdm/tiepointindex.py
@@ -73,12 +73,6 @@ class TiePointIndex(
 
             {{init data: data_like, optional}}
 
-            source: optional
-                Initialise the properties and data from those of
-                *source*.
-
-                {{init source}}
-
             {{init copy: `bool`, optional}}
 
         """

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,7 +11,7 @@ PAPER         =
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 #ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
-ALLSPHINXOPTS   = -j 2 source
+ALLSPHINXOPTS   = -j 1 source
 #ALLSPHINXOPTS   = source
 BUILDDIR        = $(filter-out $@, $(MAKECMDGOALS))
 

--- a/release_docs
+++ b/release_docs
@@ -94,6 +94,7 @@ if [[ $1 = "latest" ]] || [[ $1 = "archive" ]] ; then
 	  _templates \
 	  _downloads/cfdm_tutorial_files.zip \
 	  _downloads/tutorial.py \
+	  _images/*.png \
 	  _images/*.svg
 
   git commit -a -m "v$version $1 documentation"


### PR DESCRIPTION
Fixes #236 

The real substance is found in `cfdm/core/docstring/docstring.py`, and nearly all of the other files changes are just rolling this out.