### PR TITLE
Stop `FutureWarning` originating from `NetCDFWrite._character_array`

### DIFF
--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -323,7 +323,7 @@ class NetCDFWrite(IOWrite):
         array.resize(original_shape + (array.size // original_size,))
 
         if masked:
-            array = numpy.ma.masked_where(array == "", array)
+            array = numpy.ma.masked_where(array == b"", array)
             array.set_fill_value(fill_value)
 
         if array.dtype.kind != "S":


### PR DESCRIPTION
Directly in cfdm and downstream in cf-python, we are seeing repeated warnings of:

```
<path>/cfdm/cfdm/read_write/netcdf/netcdfwrite.py:326: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
```

for example in the start of the cfdm test suite:

```console
$ py run_tests.py 
---------------
CFDM TEST SUITE
---------------
Run date: 2023-06-05 16:47:30.926628
...
...
...
cfdm: 1.10.1.0 /home/sadie/cfdm/cfdm/__init__.py

Running tests from /home/sadie/cfdm/cfdm/test


----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
test_create_field (setup_create_field.create_fieldTest)
Test ab initio creation of a first variation of field. ... /home/sadie/cfdm/cfdm/read_write/netcdf/netcdfwrite.py:326: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  array = numpy.ma.masked_where(array == "", array)
ok

```

So this PR makes the (one-character!) fix to stop those. The warning makes it clear the source of the issue, and from investigation I see the reason the warning comes through is because `array` at point of comparison with the empty string is in bytes form.

Therefore the simplest fix is to compare with the empty byte string instead of the empty string. With that fix, as made in this PR, the warnings go away.