### PR TITLE
Actions: Python versions update to fix `int` misinterpretation

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -20,7 +20,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-18.04, macos-latest, macos-10.15]
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        # Note: keep versions quoted as strings else 3.10 taken as 3.1, etc.
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     # Run on new and old(er) versions of the distros we support (Linux, Mac OS)
     runs-on: ${{ matrix.os }}
@@ -103,7 +104,7 @@ jobs:
       # passing at least for that job, avoiding useless coverage reports.
       uses: codecov/codecov-action@v1
       if: |
-        matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
+        matrix.os == 'ubuntu-latest' && matrix.python-version == "3.9"
       with:
         file: ./cfdm/test/cfdm_coverage_reports/coverage.xml
         fail_ci_if_error: true

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Setup Miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        miniconda-version: 'latest'
+        miniconda-version: "latest"
         activate-environment: cfdm-latest
         python-version: ${{ matrix.python-version }}
         channels: anaconda
@@ -104,7 +104,7 @@ jobs:
       # passing at least for that job, avoiding useless coverage reports.
       uses: codecov/codecov-action@v1
       if: |
-        matrix.os == 'ubuntu-latest' && matrix.python-version == "3.9"
+        matrix.os == "ubuntu-latest" && matrix.python-version == "3.9"
       with:
         file: ./cfdm/test/cfdm_coverage_reports/coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
Minor fix. Sorry, I missed this in review of #273, but we need to be careful when quoting versions such as `3.10` which are subject to integer simplification in the YAML parsing, so interpreted as, for example in this case, `3.1`, when not quoted. Hence we try to run on Python 3.1 in the CI jobs (see for instance the run log for https://github.com/NCAS-CMS/cfdm/actions/runs/6610035829/job/17951188032).

The safest approach to fix this, as widely used and [advised](https://github.com/actions/runner/issues/1989), is to provide versions as strings, so I've set that across the workflows (even for versions which won't be misinterpreted, for consistency and safety).