### PR TITLE
Confirm Python 3.12 support and set to test with CI

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-18.04, macos-latest, macos-10.15]
         # Note: keep versions quoted as strings else 3.10 taken as 3.1, etc.
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     # Run on new and old(er) versions of the distros we support (Linux, Mac OS)
     runs-on: ${{ matrix.os }}

--- a/cfdm/constructs.py
+++ b/cfdm/constructs.py
@@ -376,7 +376,7 @@ class Constructs(mixin.Container, core.Constructs):
                         logger.info(
                             f"{cm0.__class__.__name__}: Different cell "
                             "methods (mismatched axes):\n  "
-                            f"{ cell_methods0}\n  {cell_methods1}"
+                            f"{cell_methods0}\n  {cell_methods1}"
                         )  # pragma: no cover
                         return False
                     elif axis0 == axis1:

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -209,7 +209,7 @@ class Data(Container, NetCDFHDF5, Files, core.Data):
             shape = str(shape)
             shape = shape.replace(",)", ")")
 
-        return f"<{ self.__class__.__name__}{shape}: {self}>"
+        return f"<{self.__class__.__name__}{shape}: {self}>"
 
     def __format__(self, format_spec):
         """Interpret format specifiers for size 1 arrays.
@@ -2010,7 +2010,7 @@ class Data(Container, NetCDFHDF5, Files, core.Data):
         except (AttributeError, ValueError):
             return self._default(
                 default,
-                f"{ self.__class__.__name__!r} has no compressed dimension",
+                f"{self.__class__.__name__!r} has no compressed dimension",
             )
 
     def _parse_indices(self, indices):

--- a/cfdm/mixin/parametersdomainancillaries.py
+++ b/cfdm/mixin/parametersdomainancillaries.py
@@ -107,7 +107,7 @@ class ParametersDomainAncillaries(Parameters):
         domain_ancillaries1 = other.domain_ancillaries()
         if set(domain_ancillaries0) != set(domain_ancillaries1):
             logger.info(
-                f"{ self.__class__.__name__}: Different domain ancillary "
+                f"{self.__class__.__name__}: Different domain ancillary "
                 "terms "
                 f"({set(domain_ancillaries0)} != {set(domain_ancillaries1)})"
             )  # pragma: no cover


### PR DESCRIPTION
I've tested locally that cfdm works with Python 3.12, so I've added this latest and greatest stable Python version to the Actions workflow for running the test suite. Updates to `pycodestyle` i.e. PEP8 now raise an error `E201 whitespace after '{'` which we run into a small number of times, so I've also fixed those up so that the full test suite passes under v3.12.

Trivial so no review necessary. Merging straight after I see the outcome of the CI job runs (we might need to wait until the ).