### PR TITLE
Detection of duplicates in API reference, some to remove

### DIFF
--- a/docs/source/check_docs_api_coverage.py
+++ b/docs/source/check_docs_api_coverage.py
@@ -84,23 +84,18 @@ for core in ("", "_core"):
                     # due to the presence of this method:
                     #     [cfdm.List.]nc_set_variable_groups
                     # so we must account for that. Checking next character
-                    # of duplicate(s) is not an underscore, is easiest.
-                    locs = [
-                        (m.start(0), m.end(0))
-                        for m in re.finditer(method, rst_contents)
+                    # of duplicate(s) is something other than a newline or
+                    # whitespace, seems robust and simplest.
+                    end_loc = [
+                        m.end(0) for m in re.finditer(method, rst_contents)
                     ]
-                    chars_at_next_loc = [
-                        m[1] for m in [lcs for lcs in locs]  # == last char + 1
-                    ]
-                    chars = [rst_contents[c] for c in chars_at_next_loc]
+                    chars = [rst_contents[c] for c in [e for e in end_loc]]
 
-                    newline_count = chars.count("\n")
-                    ws_count = chars.count(" ")
                     # Any character that isn't a newline or whitespace
                     # indicates another method which the method is a substring
                     # of and can be excluded. If there are still duplicates,
                     # we have genuine duplicate listing entries to report.
-                    if newline_count + ws_count > 1:
+                    if chars.count("\n") + chars.count(" ") > 1:
                         duplicate_method_entries.append(method)
         except FileNotFoundError:
             n_missing_files += 1

--- a/docs/source/check_docs_api_coverage.py
+++ b/docs/source/check_docs_api_coverage.py
@@ -34,6 +34,7 @@ if not source.endswith("source"):
 
 n_undocumented_methods = 0
 n_missing_files = 0
+duplicate_method_entries = []
 
 for core in ("", "_core"):
     if core:
@@ -68,12 +69,15 @@ for core in ("", "_core"):
 
             for method in methods:
                 method = ".".join([class_name, method])
-                if method not in rst_contents:
+                count = rst_contents.count(method)
+                if count == 0:
                     n_undocumented_methods += 1
                     print(
                         f"Method {method} not in "
                         f"{os.path.join(source, 'class', rst_file)}"
                     )
+                elif count > 1:
+                    duplicate_method_entries.append(method)
         except FileNotFoundError:
             n_missing_files += 1
             print(f"File {rst_file} does not exist")
@@ -89,6 +93,15 @@ if n_undocumented_methods or n_missing_files:
     raise ValueError(
         f"Found undocumented methods ({n_undocumented_methods}) "
         f"or missing .rst files ({n_missing_files})"
+    )
+
+if duplicate_method_entries:
+    duplicate_method_entries.sort()
+    entries = "\n".join(duplicate_method_entries)  # can't set \n in f-string!
+    print(
+        "WARNING: there are methods which are listed multiple times "
+        "in one class file/page. Decide if the duplicates are useful. "
+        f"They are:\n{entries}\n\n"
     )
 
 print("All non-private methods are documented")

--- a/docs/source/check_docs_api_coverage.py
+++ b/docs/source/check_docs_api_coverage.py
@@ -118,9 +118,9 @@ if duplicate_method_entries:
     duplicate_method_entries.sort()
     entries = "\n".join(duplicate_method_entries)  # can't set \n in f-string!
     print(
-        "WARNING: there are methods which are listed multiple times "
-        "in one class file/page. Decide if the duplicates are useful. "
-        f"They are:\n{entries}\n\n"
+        "WARNING: some methods are listed multiple times inside one class "
+        "file/page. Decide if the duplicates are intended and if not remove "
+        f"them. They are:\n{entries}\n"
     )
 
 print("All non-private methods are documented")

--- a/docs/source/class/cfdm.Data.rst
+++ b/docs/source/class/cfdm.Data.rst
@@ -37,6 +37,29 @@ Units
    ~cfdm.Data.has_units
    ~cfdm.Data.set_units
 
+Date-time support
+-----------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: ../method/
+   :template: method.rst
+
+   ~cfdm.Data.del_calendar
+   ~cfdm.Data.get_calendar
+   ~cfdm.Data.has_calendar
+   ~cfdm.Data.set_calendar
+
+.. rubric:: Attributes
+
+.. autosummary::
+   :nosignatures:
+   :toctree: ../attribute/
+   :template: attribute.rst
+
+   ~cfdm.Data.datetime_array
+   ~cfdm.Data.datetime_as_string
+
 Data creation routines
 ----------------------
 
@@ -102,29 +125,6 @@ Adding and removing elements
    :template: method.rst
 
    ~cfdm.Data.unique
-
-Date-time support
------------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: ../method/
-   :template: method.rst
-
-   ~cfdm.Data.del_calendar
-   ~cfdm.Data.get_calendar
-   ~cfdm.Data.has_calendar
-   ~cfdm.Data.set_calendar
-
-.. rubric:: Attributes
-
-.. autosummary::
-   :nosignatures:
-   :toctree: ../attribute/
-   :template: attribute.rst
-
-   ~cfdm.Data.datetime_array
-   ~cfdm.Data.datetime_as_string
  
 Indexing routines
 -----------------

--- a/docs/source/class/cfdm.Data.rst
+++ b/docs/source/class/cfdm.Data.rst
@@ -36,10 +36,6 @@ Units
    ~cfdm.Data.get_units
    ~cfdm.Data.has_units
    ~cfdm.Data.set_units
-   ~cfdm.Data.del_calendar
-   ~cfdm.Data.get_calendar
-   ~cfdm.Data.has_calendar
-   ~cfdm.Data.set_calendar
 
 Data creation routines
 ----------------------

--- a/docs/source/class/cfdm.Domain.rst
+++ b/docs/source/class/cfdm.Domain.rst
@@ -114,7 +114,6 @@ Miscellaneous
    :template: method.rst
 
    ~cfdm.Domain.apply_masking
-   ~cfdm.Domain.climatological_time_axes
    ~cfdm.Domain.copy
    ~cfdm.Domain.creation_commands
    ~cfdm.Domain.equals
@@ -123,7 +122,6 @@ Miscellaneous
    ~cfdm.Domain.has_bounds
    ~cfdm.Domain.has_data
    ~cfdm.Domain.has_geometry
-   ~cfdm.Domain.apply_masking   
    ~cfdm.Domain.get_original_filenames
    ~cfdm.Domain.uncompress
 

--- a/docs/source/class/cfdm.Field.rst
+++ b/docs/source/class/cfdm.Field.rst
@@ -117,10 +117,6 @@ Metadata constructs
    ~cfdm.Field.get_construct
    ~cfdm.Field.has_construct
    ~cfdm.Field.set_construct
-   ~cfdm.Field.del_data_axes
-   ~cfdm.Field.get_data_axes
-   ~cfdm.Field.has_data_axes
-   ~cfdm.Field.set_data_axes
    ~cfdm.Field.domain_axis_key
    ~cfdm.Field.auxiliary_coordinate
    ~cfdm.Field.auxiliary_coordinates

--- a/docs/source/class/cfdm.Field.rst
+++ b/docs/source/class/cfdm.Field.rst
@@ -187,7 +187,6 @@ Miscellaneous
    :toctree: ../method/
    :template: method.rst
 
-   ~cfdm.Field.climatological_time_axes
    ~cfdm.Field.compress
    ~cfdm.Field.copy
    ~cfdm.Field.creation_commands

--- a/docs/source/class/cfdm.NetCDFArray.rst
+++ b/docs/source/class/cfdm.NetCDFArray.rst
@@ -70,7 +70,6 @@ File
    ~cfdm.NetCDFArray.get_formats
    ~cfdm.NetCDFArray.get_groups
    ~cfdm.NetCDFArray.get_mask
-   ~cfdm.NetCDFArray.get_address
    
 Miscellaneous
 -------------

--- a/docs/source/class/cfdm.core.Coordinate.rst
+++ b/docs/source/class/cfdm.core.Coordinate.rst
@@ -119,21 +119,6 @@ Climatology
    ~cfdm.core.Coordinate.get_climatology
    ~cfdm.core.Coordinate.is_climatology
    ~cfdm.core.Coordinate.set_climatology
-
-Modification
-------------
-
-.. rubric:: Methods
-	    
-.. autosummary::
-   :nosignatures:
-   :toctree: ../method/
-   :template: method.rst
-
-   ~cfdm.core.Coordinate.del_data
-   ~cfdm.core.Coordinate.set_data
-   ~cfdm.core.Coordinate.del_bounds
-   ~cfdm.core.Coordinate.set_bounds
       
 Miscellaneous
 -------------

--- a/docs/source/class/cfdm.core.Data.rst
+++ b/docs/source/class/cfdm.core.Data.rst
@@ -37,6 +37,19 @@ Units
    ~cfdm.core.Data.has_units
    ~cfdm.core.Data.set_units
 
+Date-time support
+-----------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: ../method/
+   :template: method.rst
+
+   ~cfdm.core.Data.del_calendar
+   ~cfdm.core.Data.get_calendar
+   ~cfdm.core.Data.has_calendar
+   ~cfdm.core.Data.set_calendar
+
 Data creation routines
 ----------------------
 
@@ -50,19 +63,6 @@ From existing data
 
    ~cfdm.core.Data.copy
 
-Date-time support
------------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: ../method/
-   :template: method.rst
-
-   ~cfdm.core.Data.del_calendar
-   ~cfdm.core.Data.get_calendar
-   ~cfdm.core.Data.has_calendar
-   ~cfdm.core.Data.set_calendar
- 
 Mask support
 ------------
 

--- a/docs/source/class/cfdm.core.Data.rst
+++ b/docs/source/class/cfdm.core.Data.rst
@@ -36,10 +36,6 @@ Units
    ~cfdm.core.Data.get_units
    ~cfdm.core.Data.has_units
    ~cfdm.core.Data.set_units
-   ~cfdm.core.Data.del_calendar
-   ~cfdm.core.Data.get_calendar
-   ~cfdm.core.Data.has_calendar
-   ~cfdm.core.Data.set_calendar
 
 Data creation routines
 ----------------------

--- a/docs/source/class/cfdm.core.DomainAxis.rst
+++ b/docs/source/class/cfdm.core.DomainAxis.rst
@@ -37,15 +37,6 @@ Size
    ~cfdm.core.DomainAxis.has_size
    ~cfdm.core.DomainAxis.set_size
 
-.. rubric:: Attributes
-   
-.. autosummary::
-   :nosignatures:
-   :toctree: ../attribute/
-   :template: attribute.rst
-
-   ~cfdm.core.DomainAxis.construct_type
-
 Miscellaneous
 -------------
 

--- a/docs/source/class/cfdm.core.Field.rst
+++ b/docs/source/class/cfdm.core.Field.rst
@@ -91,10 +91,6 @@ Metadata constructs
    ~cfdm.core.Field.get_construct
    ~cfdm.core.Field.has_construct
    ~cfdm.core.Field.set_construct
-   ~cfdm.core.Field.del_data_axes
-   ~cfdm.core.Field.get_data_axes
-   ~cfdm.core.Field.has_data_axes
-   ~cfdm.core.Field.set_data_axes
 
 .. rubric:: Attributes
 

--- a/docs/source/class/cfdm.core.PropertiesDataBounds.rst
+++ b/docs/source/class/cfdm.core.PropertiesDataBounds.rst
@@ -77,7 +77,8 @@ Bounds
    :template: attribute.rst
 
    ~cfdm.core.PropertiesDataBounds.bounds
-   Geometries
+
+Geometries
 ^^^^^^^^^^
 
 .. rubric:: Methods

--- a/docs/source/class/cfdm.core.PropertiesDataBounds.rst
+++ b/docs/source/class/cfdm.core.PropertiesDataBounds.rst
@@ -105,21 +105,6 @@ Geometries
    :template: attribute.rst
 
    ~cfdm.core.PropertiesDataBounds.interior_ring
-
-Modification
-------------
-
-.. rubric:: Methods
-	    
-.. autosummary::
-   :nosignatures:
-   :toctree: ../method/
-   :template: method.rst
-
-   ~cfdm.core.PropertiesDataBounds.del_data
-   ~cfdm.core.PropertiesDataBounds.set_data
-   ~cfdm.core.PropertiesDataBounds.del_bounds
-   ~cfdm.core.PropertiesDataBounds.set_bounds
       
 Miscellaneous
 -------------


### PR DESCRIPTION
Took a slight tangent from my reviewing of #272 when considering API reference coverage and spotting there are some methods listed multiple times in the same file or even under the same sub-heading.

I thought I'd make a small update to the `check_docs_api_coverage` script so we can automate the detection of those when we are already checking that they are all present. So with this change we are checking they are all present precisely once and not just not zero times like before (sub-string method name complications are dealt with - see code comments), unless we've deliberately chosen to duplicate them under different headings. A warning is raised reporting any duplicates for consideration.

I've removed any duplication that seems unintended in the API reference source restructured text, thought left in some cases where it looks like we might want to put methods under multiple headings. Namely, at PR opening the script still reports these which I haven't touched:

```console
$ ./check_docs_api_coverage
WARNING: some methods are listed multiple times inside one class file/page. Decide if the duplicates are intended and if not remove them. They are:
cfdm.Data.del_calendar
cfdm.Data.get_calendar
cfdm.Data.has_calendar
cfdm.Data.set_calendar
cfdm.Data.sum
cfdm.Data.unique
cfdm.Field.del_data_axes
cfdm.Field.get_data_axes
cfdm.Field.has_data_axes
cfdm.Field.set_data_axes
cfdm.core.Coordinate.del_bounds
cfdm.core.Coordinate.del_data
cfdm.core.Coordinate.set_bounds
cfdm.core.Coordinate.set_data
cfdm.core.Data.del_calendar
cfdm.core.Data.get_calendar
cfdm.core.Data.has_calendar
cfdm.core.Data.set_calendar
cfdm.core.Field.del_data_axes
cfdm.core.Field.get_data_axes
cfdm.core.Field.has_data_axes
cfdm.core.Field.set_data_axes
cfdm.core.PropertiesDataBounds.del_bounds
cfdm.core.PropertiesDataBounds.del_data
cfdm.core.PropertiesDataBounds.set_bounds
cfdm.core.PropertiesDataBounds.set_data

All non-private methods are documented
```

as opposed to, previously, a longer list:

```console
WARNING: there are methods which are listed multiple times in one class file/page. Decide if the duplicates are useful. They are:
cfdm.Data.del_calendar
cfdm.Data.get_calendar
cfdm.Data.has_calendar
cfdm.Data.set_calendar
cfdm.Data.sum
cfdm.Data.unique
cfdm.Domain.apply_masking
cfdm.Domain.climatological_time_axes
cfdm.Field.climatological_time_axes
cfdm.Field.del_data_axes
cfdm.Field.get_data_axes
cfdm.Field.has_data_axes
cfdm.Field.set_data_axes
cfdm.NetCDFArray.get_address
cfdm.core.Coordinate.del_bounds
cfdm.core.Coordinate.del_data
cfdm.core.Coordinate.set_bounds
cfdm.core.Coordinate.set_data
cfdm.core.Data.del_calendar
cfdm.core.Data.get_calendar
cfdm.core.Data.has_calendar
cfdm.core.Data.set_calendar
cfdm.core.DomainAxis.construct_type
cfdm.core.Field.del_data_axes
cfdm.core.Field.get_data_axes
cfdm.core.Field.has_data_axes
cfdm.core.Field.set_data_axes
cfdm.core.PropertiesDataBounds.del_bounds
cfdm.core.PropertiesDataBounds.del_data
cfdm.core.PropertiesDataBounds.set_bounds
cfdm.core.PropertiesDataBounds.set_data


All non-private methods are documented
```

Happy to remove those duplicates from the first snippet too, though? But the main thing is the automation of the check and that I've removed methods duplicated under the same heading, which can be blitzed to tidy.