### PR TITLE
CI: fixes and updates to pre-commit workflow for linting pass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
   # (see https://flake8.pycqa.org/en/latest/ for documentation and see
   # the cfdm .flake8 file for our custom flake8 configuration)
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
 


### PR DESCRIPTION
#283 shows that the linting workflow is running into numerous failures, mostly E231, which I don't see locally. This is to update the workflow and/or make fixes so we are up-to-date and can see only actual linting issues.

[WIP as I check the results of the CI jobs, since locally the linting passes for me so it us harder to isolate there what versions etc. are causing the (majority of the) error code violation raises.]