### PR TITLE
`netcdfread`: safer version handling for `Conventions` property

### DIFF
--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -1020,9 +1020,10 @@ class NetCDFRead(IORead):
 
         # ------------------------------------------------------------
         # Find the CF version for the file, and the CFA version.
+        # (See '2.6.1 Identification of Conventions' in the CF Conformance
+        # document for valid inputs for the 'Conventions' property.)
         # ------------------------------------------------------------
         Conventions = g["global_attributes"].get("Conventions", "")
-
         # If the string contains any commas, it is assumed to be a
         # comma-separated list.
         all_conventions = re.split(r",\s*", Conventions)
@@ -1032,13 +1033,15 @@ class NetCDFRead(IORead):
         file_version = None
         for c in all_conventions:
             # Be particularly strict with the regex to account for ambiguous
-            # values e.g. CF-<badversionformat> or CF-1.X/CF-1.Y. Note that
-            # the '^' and '$' start and end of string tokens ensure that
-            # only zero or one match can be found per given string c (hence
-            # taking group(1) when given conditional is True below is safe).
-            cf_v = re.search(r"^CF-(\d+.\d+)$", c)
-            u_v = re.search(r"^UGRID-(\d+.\d+)$", c)
-            cfa_v = re.search(r"^CFA-(\d+.\d+)$", c)
+            # values e.g. CF-<badversionformat> or CF-1.X/CF-1.Y. Note that:
+            #   * the '^' and '$' start and end of string tokens ensure that
+            #     only zero or one match can be found per given string c;
+            #   * the '(\d+(.\d+)*)' regex ensures a valid input to
+            #     Version(), allowing any level of versioning identifier
+            #     detail e.g. 1.23.34.45.6 (for future-proofing).
+            cf_v = re.search(r"^CF-(\d+(.\d+)*)$", c)
+            u_v = re.search(r"^UGRID-(\d+(.\d+)*)$", c)
+            cfa_v = re.search(r"^CFA-(\d+(.\d+)*)$", c)
 
             if cf_v:
                 file_version = cf_v.group(1)

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -1069,6 +1069,11 @@ class NetCDFRead(IORead):
                 file_version = self.implementation.get_cf_version()
 
         g["file_version"] = Version(file_version)
+        if is_log_level_debug(logger):
+            logger.debug(
+                "    Versioning:\n        read_vars['file_version'] ="
+                f"{g['file_version']}"
+            )  # pragma: no cover
 
         # Set minimum/maximum versions
         for vn in ("1.6", "1.7", "1.8", "1.9", "1.10", "1.11"):

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -1039,6 +1039,8 @@ class NetCDFRead(IORead):
             #   * the '(\d+(.\d+)*)' regex ensures a valid input to
             #     Version(), allowing any level of versioning identifier
             #     detail e.g. 1.23.34.45.6 (for future-proofing).
+            #     See https://packaging.python.org/en/latest/specifications/
+            #         version-specifiers/ for more on valid input to Version()
             v_id = r"^{}-(\d+(.\d+)*)$"
             cf_v = re.search(v_id.format("CF"), c)
             u_v = re.search(v_id.format("UGRID"), c)
@@ -1046,13 +1048,17 @@ class NetCDFRead(IORead):
 
             # For the case of CF, also valid is 'CF-X-draft', where X
             # is the present but unreleased version, e.g. "CF-1.12-draft".
-            v_id_draft = v_id[:-2] + "-draft)$"  # == + "draft" + v_id[-2:]
+            v_id_draft = v_id[:-2] + "-draft)$"  # i.e. + "draft" + v_id[-2:]
             cf_v_draft = re.search(v_id_draft.format("CF"), c)
 
             if cf_v:
                 file_version = cf_v.group(1)
             elif cf_v_draft:
-                file_version = cf_v_draft.group(1)
+                # TODO: what should we set when Conventions=X.Y-draft?
+                # Is it best to set to the X.Y i.e. upcoming version, though
+                # it only obeys a draft state of that which may be updated
+                # so that it becoes non-conformant? If so, set as follows:
+                file_version = cf_v_draft.group(1).rstrip("-draft")
             elif u_v:
                 # Allow UGRID if it has been specified in Conventions,
                 # regardless of the version of CF.

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -1025,7 +1025,7 @@ class NetCDFRead(IORead):
 
         # If the string contains any commas, it is assumed to be a
         # comma-separated list.
-        all_conventions = re.split(",\s*", Conventions)
+        all_conventions = re.split(r",\s*", Conventions)
         if all_conventions[0] == Conventions:
             all_conventions = Conventions.split()
 

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -1046,20 +1046,8 @@ class NetCDFRead(IORead):
             u_v = re.search(v_id.format("UGRID"), c)
             cfa_v = re.search(v_id.format("CFA"), c)
 
-            # For the case of CF, also valid is 'CF-X-draft', where X
-            # is the present but unreleased version, e.g. "CF-1.12-draft".
-            v_id_draft = v_id[:-2] + "-draft)$"  # i.e. + "draft" + v_id[-2:]
-            cf_v_draft = re.search(v_id_draft.format("CF"), c)
-
-            print(c, "TESTING AGAINST", cf_v, u_v, cfa_v)
             if cf_v:
                 file_version = cf_v.group(1)
-            elif cf_v_draft:
-                # TODO: what should we set when Conventions=X.Y-draft?
-                # Is it best to set to the X.Y i.e. upcoming version, though
-                # it only obeys a draft state of that which may be updated
-                # so that it becoes non-conformant? If so, set as follows:
-                file_version = cf_v_draft.group(1).rstrip("-draft")
             elif u_v:
                 # Allow UGRID if it has been specified in Conventions,
                 # regardless of the version of CF.

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -1036,12 +1036,12 @@ class NetCDFRead(IORead):
             # values e.g. CF-<badversionformat> or CF-1.X/CF-1.Y. Note that:
             #   * the '^' and '$' start and end of string tokens ensure that
             #     only zero or one match can be found per given string c;
-            #   * the '(\d+(.\d+)*)' regex ensures a valid input to
+            #   * the regex below ensures a valid input to
             #     Version(), allowing any level of versioning identifier
             #     detail e.g. 1.23.34.45.6 (for future-proofing).
             #     See https://packaging.python.org/en/latest/specifications/
             #         version-specifiers/ for more on valid input to Version()
-            v_id = r"^{}-(\d+(.\d+)*)$"
+            v_id = r"^{}-(\d+(\.\d+)*)$"
             cf_v = re.search(v_id.format("CF"), c)
             u_v = re.search(v_id.format("UGRID"), c)
             cfa_v = re.search(v_id.format("CFA"), c)
@@ -1051,6 +1051,7 @@ class NetCDFRead(IORead):
             v_id_draft = v_id[:-2] + "-draft)$"  # i.e. + "draft" + v_id[-2:]
             cf_v_draft = re.search(v_id_draft.format("CF"), c)
 
+            print(c, "TESTING AGAINST", cf_v, u_v, cfa_v)
             if cf_v:
                 file_version = cf_v.group(1)
             elif cf_v_draft:

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -1032,7 +1032,9 @@ class NetCDFRead(IORead):
         file_version = None
         for c in all_conventions:
             if c.startswith("CF-"):
-                file_version = c.replace("CF-", "", 1)
+                # Exclude ambiguous edge cases e.g. CF-1.X/CF-1.Y (seen IRL)
+                if c.count("CF-") == 1:
+                    file_version = c.replace("CF-", "", 1)
             elif c.startswith("UGRID-"):
                 # Allow UGRID if it has been specified in Conventions,
                 # regardless of the version of CF.

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -1039,12 +1039,20 @@ class NetCDFRead(IORead):
             #   * the '(\d+(.\d+)*)' regex ensures a valid input to
             #     Version(), allowing any level of versioning identifier
             #     detail e.g. 1.23.34.45.6 (for future-proofing).
-            cf_v = re.search(r"^CF-(\d+(.\d+)*)$", c)
-            u_v = re.search(r"^UGRID-(\d+(.\d+)*)$", c)
-            cfa_v = re.search(r"^CFA-(\d+(.\d+)*)$", c)
+            v_id = r"^{}-(\d+(.\d+)*)$"
+            cf_v = re.search(v_id.format("CF"), c)
+            u_v = re.search(v_id.format("UGRID"), c)
+            cfa_v = re.search(v_id.format("CFA"), c)
+
+            # For the case of CF, also valid is 'CF-X-draft', where X
+            # is the present but unreleased version, e.g. "CF-1.12-draft".
+            v_id_draft = v_id[:-2] + "-draft)$"  # == + "draft" + v_id[-2:]
+            cf_v_draft = re.search(v_id_draft.format("CF"), c)
 
             if cf_v:
                 file_version = cf_v.group(1)
+            elif cf_v_draft:
+                file_version = cf_v_draft.group(1)
             elif u_v:
                 # Allow UGRID if it has been specified in Conventions,
                 # regardless of the version of CF.

--- a/cfdm/read_write/read.py
+++ b/cfdm/read_write/read.py
@@ -18,6 +18,7 @@ def read(
     mask=True,
     domain=False,
     _implementation=_implementation,
+    _scan_only=False,
 ):
     """Read field or domain constructs from a dataset.
 
@@ -335,6 +336,7 @@ def read(
                 mask=mask,
                 domain=domain,
                 extra_read_vars=None,
+                _scan_only=_scan_only,
             )
         except MaskError:
             # Some data required for field interpretation is missing,

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -704,6 +704,8 @@ class read_writeTest(unittest.TestCase):
 
     def test_read_write_Conventions_version(self):
         """Test processing of `Conventions` attribute to field property."""
+        from packaging.version import Version
+
         f = cfdm.read(self.filename)[0]
 
         # Construct single valid values for standards
@@ -781,8 +783,14 @@ class read_writeTest(unittest.TestCase):
             n.Conventions = set_conv_value
             n.close()
 
+            self.assertEqual(
+                cfdm.read(tmpfile, _scan_only=True)["file_version"],
+                Version(get_conv_value.lstrip("CF-"))
+            )
             g = cfdm.read(tmpfile)[0]
-            self.assertEqual(g.get_property("Conventions"), get_conv_value)
+            # TODO: do we want to re-set the Conventions property as well,
+            # given it is invalid?
+            self.assertEqual(g.get_property("Conventions"), set_conv_value)
 
     def test_read_write_Conventions(self):
         """Test the `Conventions` keyword argument to `write`."""


### PR DESCRIPTION
Close #295, ~~close #297,~~ close #298, close #301.

~~Waiting on some clarifications to https://github.com/orgs/cf-convention/discussions/321 and to https://github.com/NCAS-CMS/cfdm/issues/298 before updating and converting from draft form ready for review.~~
https://github.com/orgs/cf-convention/discussions/321 has confirmed that we don't have to worry about a '-draft' possibility in the `Conventions` attribute value, so #297 is a non-issue I have closed. I will now update the PR accordingly to revert anything related to that and open it for review.