### PR TITLE
Fix `cfdm.write` when a parametric Z dimension coordinate does not have a compute_standard_name attribute

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -5,6 +5,9 @@ Version NEXTRELEASE
 
 * Upgrades to allow cfdm to work with Python 3.12
   (https://github.com/NCAS-CMS/cfdm/issues/302)
+* Fix bug that caused `cfdm.write` to fail when a parametric Z
+  dimension coordinate did not have a ``computed_standard_name``
+  attribute (https://github.com/NCAS-CMS/cfdm/issues/303)
 
 ----
 

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -3323,7 +3323,7 @@ class NetCDFWrite(IOWrite):
                 coord, "computed_standard_name", None
             )
             if x is None:
-                self.implementation.set_property(
+                self.implementation.set_properties(
                     field_coordinates[key],
                     {"computed_standard_name": csn},
                     copy=False,

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -1001,6 +1001,16 @@ class read_writeTest(unittest.TestCase):
             f = cfdm.read(remote)
             self.assertEqual(len(f), 1)
 
+    def test_write_parametric_Z_coordinate(self):
+        """Test write of parametric Z coordinate."""
+        # Thes write when a parametric Z dimension coordinate does not
+        # have a compute_standard_name attribute
+        f = cfdm.example_field(1)
+        f.coordinate("atmosphere_hybrid_height_coordinate").del_property(
+            "computed_standard_name", None
+        )
+        cfdm.write(f, tmpfile)
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())


### PR DESCRIPTION
Fixes #303

Just a typo, really.