### PR TITLE
Update linting package versions for Python 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   # Use specific format-enforcing pre-commit hooks from the core library
   # with the default configuration (see pre-commit.com for documentation)
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-ast
       - id: debug-statements
@@ -23,7 +23,7 @@ repos:
   # (see https://black.readthedocs.io/en/stable/ for documentation and see
   # the cfdm pyproject.toml file for our custom black configuration)
   - repo: https://github.com/ambv/black
-    rev: 23.1.0
+    rev: 24.4.2
     hooks:
       - id: black
         language_version: python3
@@ -59,7 +59,7 @@ repos:
   # (see https://flake8.pycqa.org/en/latest/ for documentation and see
   # the cfdm .flake8 file for our custom flake8 configuration)
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.1.0
     hooks:
       - id: flake8
 
@@ -68,7 +68,7 @@ repos:
   # compatible with 'black' with the lines set to ensure so in the repo's
   # pyproject.toml. Other than that and the below, no extra config is required.
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)

--- a/cfdm/__init__.py
+++ b/cfdm/__init__.py
@@ -36,6 +36,7 @@ Note that cfdm enables the creation of CF field constructs, but it's
 up to the user to use them in a CF-compliant way.
 
 """
+
 import logging
 import sys
 

--- a/cfdm/core/docstring/docstring.py
+++ b/cfdm/core/docstring/docstring.py
@@ -20,6 +20,7 @@ Keys must be a `str` or `re.Pattern` object:
 .. versionaddedd:: (cfdm) 1.8.7.0
 
 """
+
 _docstring_substitution_definitions = {
     # ----------------------------------------------------------------
     # General susbstitutions (not indent-dependent)

--- a/cfdm/docstring/docstring.py
+++ b/cfdm/docstring/docstring.py
@@ -21,7 +21,6 @@ Keys must be a `str` or `re.Pattern` object:
 
 """
 
-
 _docstring_substitution_definitions = {
     # ----------------------------------------------------------------
     # General substitutions (not indent-dependent)

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -1231,10 +1231,10 @@ class NetCDFRead(IORead):
                                 variable_attributes[ncvar][attr]
                             )
                         except UnicodeEncodeError:
-                            variable_attributes[ncvar][
-                                attr
-                            ] = variable_attributes[ncvar][attr].encode(
-                                errors="ignore"
+                            variable_attributes[ncvar][attr] = (
+                                variable_attributes[ncvar][attr].encode(
+                                    errors="ignore"
+                                )
                             )
                 except UnicodeDecodeError:
                     pass
@@ -6251,12 +6251,12 @@ class NetCDFRead(IORead):
                         for term, param_ncvar in rec[
                             "interpolation_parameters"
                         ].items():
-                            interpolation_parameters[
-                                term
-                            ] = self._copy_construct(
-                                "interpolation_parameter",
-                                parent_ncvar,
-                                param_ncvar,
+                            interpolation_parameters[term] = (
+                                self._copy_construct(
+                                    "interpolation_parameter",
+                                    parent_ncvar,
+                                    param_ncvar,
+                                )
                             )
 
                             # For each intepolation parameter, record
@@ -8428,9 +8428,11 @@ class NetCDFRead(IORead):
                 mapping = self.read_vars["flattener_variables"]
                 if trailing_colon:
                     out = [
-                        mapping[ncvar[:-1]] + ":"
-                        if ncvar.endswith(":")
-                        else mapping[ncvar]
+                        (
+                            mapping[ncvar[:-1]] + ":"
+                            if ncvar.endswith(":")
+                            else mapping[ncvar]
+                        )
                         for ncvar in out
                     ]
                 else:
@@ -9105,9 +9107,9 @@ class NetCDFRead(IORead):
 
         # Create data
         if cell == "point":
-            properties[
-                "long_name"
-            ] = "Maps every point to its connected points"
+            properties["long_name"] = (
+                "Maps every point to its connected points"
+            )
             indices, kwargs = self._create_netcdfarray(connectivity_ncvar)
             n_nodes = self.read_vars["internal_dimension_sizes"][
                 mesh.ncdim[location]

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -2673,7 +2673,7 @@ class NetCDFWrite(IOWrite):
             datatype = self._datatype(cfvar)
             data, ncdimensions = self._transform_strings(
                 data,
-                ncdimensions
+                ncdimensions,
                 #                cfvar, data, ncdimensions
             )
 

--- a/docs/source/check_docs_api_coverage.py
+++ b/docs/source/check_docs_api_coverage.py
@@ -15,6 +15,7 @@ Call as:
    $ python check_api_coverage.py <docs/source/ directory path>
 
 """
+
 import os
 import re
 import sys

--- a/docs/source/extract_tutorial_code.py
+++ b/docs/source/extract_tutorial_code.py
@@ -1,4 +1,5 @@
 """Extract tutorial Python code into an executable Python script."""
+
 import re
 import sys
 


### PR DESCRIPTION
Update linting package versions for Python 3.12, specifically to cope with the changes to f-string syntax.