### PR TITLE
Prevent read error for datasets including badly-encoded UGRID meshes

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -22,6 +22,9 @@ Version NEXTVERSION
 * Fix bug that caused `cfdm.write` to fail when a parametric Z
   dimension coordinate did not have a ``computed_standard_name``
   attribute (https://github.com/NCAS-CMS/cfdm/issues/303)
+* Fix bug that caused `cfdm.read` to fail to read at all
+  datasets including variables with badly-encoded UGRID meshes
+  (https://github.com/NCAS-CMS/cfdm/issues/315)
 * New class `cfdm.H5netcdfArray`
 * New class `cfdm.NetCDF4Array`
 * New dependency: ``h5netcdf>=1.3.0``

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -9,7 +9,6 @@ from ast import literal_eval
 from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import reduce
-from math import nan, prod
 from pprint import pformat
 from math import log, nan, prod
 from numbers import Integral

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import reduce
 from math import nan, prod
+from pprint import pformat
 from typing import Any
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -3787,9 +3788,10 @@ class NetCDFRead(IORead):
                     ugrid = False
                     logger.warning(
                         "There was a problem parsing the UGRID mesh "
-                        f"topology variable {mesh.mesh_ncvar!r}: "
-                        f"Ignoring the UGRID mesh for {field_ncvar!r}."
+                        "topology variable. Ignoring the UGRID mesh "
+                        f"for {field_ncvar!r}."
                     )
+                    logger.debug(f"Mesh dictionary is: {pformat(g['mesh'])}")
 
             if ugrid:
                 # The UGRID specification is OK, so get the auxiliary


### PR DESCRIPTION
Closes #315. For the need for a quite specific dataset to test against and lack of bandwidth before we are due to do the new release set, I am not adding a test to capture the bug, which I appreciate is not ideal but there is a test in the new cf-plot suite which exposed this, which I think is good enough*.

*This involves updating the code snippet for the [appropriate cf-plot example](https://ncas-cms.github.io/cf-plot/build/unstructured.html#unstructured-grids-and-ugrid), where the field indexing seems to have changed so that I've matched the relevant fields like so to update it to work with this branch, whereas before it hit the error covered in the associated issue on the initial `read`:

```python
>>> f = cf.read("/home/slb93/git-repos/cf-plot/cfplot/test/cfplot_data/lfric_initial.nc")
There was a problem parsing the UGRID mesh topology variable. Ignoring the UGRID mesh for 'u1'.
There was a problem parsing the UGRID mesh topology variable. Ignoring the UGRID mesh for 'u2'.
>>> pot = f.select_by_identity("air_potential_temperature")[0]
>>> lats = f.select_by_identity("latitude")[0]
>>> lons = f.select_by_identity("longitude")[0]
>>> faces = f.select_by_identity("cf_role=face_edge_connectivity")[1]  # try second of two
>>> pot_crop = pot[4,:]  # reduce
>>> cfp.con(f=pot_crop, face_lons=lons, face_lats=lats, face_connectivity=faces, lines=False)

```