### PR TITLE
Reinstate cfdm.Data.datetime_as_array

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,12 @@
+Version 1.11.2.1
+----------------
+
+**2025-02-26**
+
+* Re-introduction of `cfdm.Data.datetime_as_array`
+
+----
+  
 Version 1.11.2.0
 ----------------
 

--- a/cfdm/core/__init__.py
+++ b/cfdm/core/__init__.py
@@ -11,9 +11,9 @@ datasets and the inspection of CF data model constructs.
 
 """
 
-__date__ = "2025-01-28"
+__date__ = "2025-02-26"
 __cf_version__ = "1.11"
-__version__ = "1.11.2.0"
+__version__ = "1.11.2.1"
 
 from packaging import __version__ as _packaging_ver
 from packaging import __file__ as _packaging_file

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -2612,6 +2612,44 @@ class Data(Container, NetCDFHDF5, Files, core.Data):
         return a
 
     @property
+    def datetime_as_string(self):
+        """Returns an independent numpy array with datetimes as strings.
+
+        Specifically, returns an independent numpy array containing
+        string representations of times since a reference date.
+
+        Only applicable for reference time units.
+
+        If the calendar has not been set then the CF default calendar of
+        "standard" (i.e. the mixed Gregorian/Julian calendar as defined by
+        Udunits) will be used.
+
+        Conversions are carried out with the `netCDF4.num2date` function.
+
+        .. versionadded:: (cfdm) 1.8.0
+
+        .. seealso:: `array`, `datetime_array`
+
+        :Returns:
+
+            `numpy.ndarray`
+                An independent numpy array of the date-time strings.
+
+        **Examples**
+
+        >>> d = {{package}}.{{class}}([31, 62, 90], units='days since 2018-12-01')
+        >>> print(d.datetime_as_string)
+        ['2019-01-01 00:00:00' '2019-02-01 00:00:00' '2019-03-01 00:00:00']
+
+        >>> d = {{package}}.{{class}}(
+        ...     [31, 62, 90], units='days since 2018-12-01', calendar='360_day')
+        >>> print(d.datetime_as_string)
+        ['2019-01-02 00:00:00' '2019-02-03 00:00:00' '2019-03-01 00:00:00']
+
+        """
+        return self.datetime_array.astype(str)
+
+    @property
     def dtype(self):
         """The `numpy` data-type of the data.
 

--- a/cfdm/test/test_Data.py
+++ b/cfdm/test/test_Data.py
@@ -1612,6 +1612,16 @@ class DataTest(unittest.TestCase):
             a = d.array
             self.assertTrue((a == x).all())
 
+    def test_Data_datetime_as_string(self):
+        """Test the `datetime_as_string` Data property."""
+        d = cfdm.Data([11292.5, 11293.5], "days since 1970-1-1")
+        array = d.datetime_as_string
+        self.assertEqual(array.dtype.kind, "U")
+
+        self.assertTrue(
+            (array == ["2000-12-01 12:00:00", "2000-12-02 12:00:00"]).all()
+        )
+
     def test_Data_compute(self):
         """Test Data.compute."""
         # Scalar numeric array


### PR DESCRIPTION
Reinstate cfdm.Data.datetime_as_array, that accidentally got removed after 1.11.1.0