### PR TITLE
Add `distributed` as required dependency with version pin

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,12 @@
+Version NEXTVERSION
+--------------
+
+**2025-??-??**
+
+* New dependency: ``distributed>=2025.5.1``
+
+----
+
 Version 1.12.2.0
 ----------------
 

--- a/cfdm/__init__.py
+++ b/cfdm/__init__.py
@@ -166,6 +166,20 @@ else:
             f"Got {dask.__version__} at {dask.__file__}"
         )
 
+# Check the version of distributed
+try:
+    import distributed
+except ImportError as error1:
+    raise ImportError(_error0 + str(error1))
+else:
+    _minimum_vn = "2025.5.1"
+    if Version(distributed.__version__) < Version(_minimum_vn):
+        raise ValueError(
+            "Bad distributed version: cfdm requires "
+            f"distributed>={_minimum_vn}. "
+            f"Got {distributed.__version__} at {distributed.__file__}"
+        )
+
 # Check the version of uritools
 try:
     import uritools

--- a/cfdm/functions.py
+++ b/cfdm/functions.py
@@ -429,6 +429,7 @@ def environment(display=True, paths=True):
     s3fs: 2024.12.0
     scipy: 1.15.1
     dask: 2025.5.1
+    distributed: 2025.5.1
     cftime: 1.6.4.post1
     cfunits: 3.3.7
     cfdm: 1.12.2.0
@@ -452,6 +453,7 @@ def environment(display=True, paths=True):
         "s3fs": _get_module_info("s3fs"),
         "scipy": _get_module_info("scipy"),
         "dask": _get_module_info("dask"),
+        "distributed": _get_module_info("distributed"),
         "cftime": _get_module_info("cftime"),
         "cfunits": _get_module_info("cfunits"),
         "cfdm": (__version__, os.path.abspath(__file__)),

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -199,7 +199,10 @@ The cfdm package requires:
     
 * `s3fs <https://pypi.org/project/s3fs>`_, version 2024.6.0 or newer.
 
-* `dask <https://pypi.org/project/dask>`_, versions 2025.5.1 or newer.
+* `dask <https://pypi.org/project/dask>`_, version 2025.5.1 or newer.
+
+* `distributed <https://pypi.org/project/distributed>`_, version 2025.5.1
+  or newer.
 
 * `packaging <https://pypi.org/project/packaging>`_, version 20.0 or
   newer.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ h5netcdf>=1.3.0
 h5py>=3.12.0
 s3fs>=2024.6.0
 dask>=2025.5.1
+distributed>=2025.5.1
 uritools>=4.0.3
 cfunits>=3.3.7
 zarr>=3.0.8


### PR DESCRIPTION
As per NCAS-CMS/cf-python#876. Doing here also for safety. The two PRs are pretty much mirrors of each other, except with respect to the `cf[dm].environment` functions notably where `cfdm` handles the report on `distributed` for cf-python to spit out as part of the cfdm requirements.