### PR TITLE
Fix `cfdm.Data.reshape` when the underlying data originate on disk

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,6 +3,8 @@ Version NEXTVERSION
 
 **2025-??-??**
 
+* Fix `cfdm.Data.reshape` when the underlying data originate on disk
+  (https://github.com/NCAS-CMS/cfdm/issues/348)
 * New keyword parameter to `cfdm.Field.dump`: ``data``
   (https://github.com/NCAS-CMS/cfdm/issues/345)
 * New dependency: ``distributed>=2025.5.1``

--- a/cfdm/data/data.py
+++ b/cfdm/data/data.py
@@ -6560,11 +6560,9 @@ class Data(Container, NetCDFAggregation, NetCDFChunks, Files, core.Data):
         original_shape = self.shape
         original_ndim = len(original_shape)
 
-        dx = d.to_dask_array(
-            _force_mask_hardness=False, _force_to_memory=False
-        )
+        dx = d.to_dask_array(_force_mask_hardness=False)
         dx = dx.reshape(*shape, merge_chunks=merge_chunks, limit=limit)
-        d._set_dask(dx, in_memory=None)
+        d._set_dask(dx, in_memory=True)
 
         # Set axis names for the reshaped data
         if dx.ndim != original_ndim:

--- a/cfdm/test/test_Data.py
+++ b/cfdm/test/test_Data.py
@@ -1764,6 +1764,14 @@ class DataTest(unittest.TestCase):
         d = cfdm.Data([8, 9])
         self.assertEqual(len(d.reshape(1, 2)._axes), 2)
 
+        # Test when underlying data is in a `FileAarray` object
+        # (i.e. on disk)
+        f = cfdm.write(self.f0, file_A)
+        f = cfdm.read(file_A)[0]
+        d = f.data
+        e = d.reshape((1,) + d.shape)
+        self.assertTrue(np.allclose(e[0], d))
+
     def test_Data_get_units(self):
         """Test Data.get_units."""
         for units in ("", "m", "days since 2000-01-01"):


### PR DESCRIPTION
Fixes #348 