### PR TITLE
[Superseded by #383] Fix bug in `cfdm.write` when writing identical coordinates that have different "formula_terms"

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -5,7 +5,7 @@ Version NEXTVERSION
 
 * Fix bug in `cfdm.write` when writing identical coordinates that have
   different ``formula_terms``
-  (https://github.com/NCAS-CMS/cfdm/issues/380)
+  (https://github.com/NCAS-CMS/cfdm/issues/380). New unit test added.
 
 ----
 

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,13 @@
+Version NEXTVERSION
+----------------
+
+**2026-03-??**
+
+* Fix `cfdm.write` for the writing of coordinates with formula_terms
+  (https://github.com/NCAS-CMS/cfdm/issues/???)
+
+----
+
 Version 1.13.0.0
 ----------------
 

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,8 +3,9 @@ Version NEXTVERSION
 
 **2026-03-??**
 
-* Fix `cfdm.write` for the writing of coordinates with formula_terms
-  (https://github.com/NCAS-CMS/cfdm/issues/???)
+* Fix bug in `cfdm.write` when writing identical coordinates that have
+  different ``formula_terms``
+  (https://github.com/NCAS-CMS/cfdm/issues/380)
 
 ----
 

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -36,6 +36,7 @@ tmpfiles.append(tempfile.mkstemp("#test_read_write.nc", dir=os.getcwd())[1])
     tmpfile0,
     tmpfile1,
     tmpfile_hash,
+    tmpfile_formula_terms
 ] = tmpfiles
 
 

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -1361,12 +1361,16 @@ class read_writeTest(unittest.TestCase):
         self.assertTrue(g.equals(f))
 
     def test_differing_formula_terms(self):
+        # Read in example field with shape (1, 10, 9)
         f = cfdm.example_field(1)
         
+        # Write dummy file with original field and a slice.
         cfdm.write([f, f[0, 1:]], tmpfile_formula_terms)
 
+        # Read file back in.
         g = cfdm.read(tmpfile_formula_terms)
 
+        # Check file and slice are the same shape.
         self.assertTrue(g[1].equals(f[0, 1:], verbose=True))
 
 

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -36,7 +36,7 @@ tmpfiles.append(tempfile.mkstemp("#test_read_write.nc", dir=os.getcwd())[1])
     tmpfile0,
     tmpfile1,
     tmpfile_hash,
-    tmpfile_formula_terms
+    tmpfile_formula_terms,
 ] = tmpfiles
 
 

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -1359,6 +1359,15 @@ class read_writeTest(unittest.TestCase):
         g = cfdm.read(tmpfile_hash)[0]
         self.assertTrue(g.equals(f))
 
+    def test_differing_formula_terms(self):
+        f = cfdm.example_field(1)
+        
+        cfdm.write([f, f[0, 1:]], tmpfile_formula_terms)
+
+        g = cfdm.read(tmpfile_formula_terms)
+
+        self.assertTrue(g[1].equals(f[0, 1:], verbose=True))
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())


### PR DESCRIPTION
~Fixes issue 380~ 

Superseded by #383 