### PR TITLE
Fix bug in `cfdm.write` when writing identical coordinates that have different "formula_terms"

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -5,7 +5,7 @@ Version NEXTVERSION
 
 * Fix bug in `cfdm.write` when writing identical coordinates that have
   different ``formula_terms``
-  (https://github.com/NCAS-CMS/cfdm/issues/380)
+  (https://github.com/NCAS-CMS/cfdm/issues/380). New unit test added.
 
 ----
 

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,13 @@
+Version NEXTVERSION
+----------------
+
+**2026-03-??**
+
+* Fix `cfdm.write` for the writing of coordinates with formula_terms
+  (https://github.com/NCAS-CMS/cfdm/issues/???)
+
+----
+
 Version 1.13.0.0
 ----------------
 

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,8 +3,9 @@ Version NEXTVERSION
 
 **2026-03-??**
 
-* Fix `cfdm.write` for the writing of coordinates with formula_terms
-  (https://github.com/NCAS-CMS/cfdm/issues/???)
+* Fix bug in `cfdm.write` when writing identical coordinates that have
+  different ``formula_terms``
+  (https://github.com/NCAS-CMS/cfdm/issues/380)
 
 ----
 

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -795,7 +795,7 @@ class NetCDFWrite(IOWrite):
             if not ncvar.startswith(groups):
                 create = True
 
-        # Do these coordinates need a formula_terms?
+        # Do these coordinates need a formula_terms attribute?
         formula_terms = False
         for ref in f.coordinate_references(todict=True).values():
             if (
@@ -807,7 +807,7 @@ class NetCDFWrite(IOWrite):
 
         if formula_terms and already_in_file and not create:
             if not self._matching_coordinate_formula_terms(f, ref, coord):
-                # This a coordiante variable for this dimension
+                # This a coordinate variable for this dimension
                 # coordinate is already in the file, but we need to
                 # create a new one because it has a different
                 # formula_terms to the one that's already in the file.
@@ -816,8 +816,8 @@ class NetCDFWrite(IOWrite):
         if create:
             if formula_terms:
                 # Record the (field, coordinate reference, dimension
-                # cooridnate) triple for comparison with fields that
-                # may written later on.
+                # coordinate) triple for comparison with fields that
+                # may be written later on.
                 g["field_ref_coord"].append((f, ref, coord))
 
             ncvar = self._create_variable_name(coord, default=None)
@@ -6920,7 +6920,7 @@ class NetCDFWrite(IOWrite):
         return mv
 
     def _matching_coordinate_formula_terms(self, f, ref, coord):
-        """Is the coord/formula_terms pair already in the dataset?
+        """Is the coordinate/formula_terms pair already in the dataset?
 
         .. versionadded:: (cfdm) NEXTVERSION
 

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -36,6 +36,7 @@ tmpfiles.append(tempfile.mkstemp("#test_read_write.nc", dir=os.getcwd())[1])
     tmpfile0,
     tmpfile1,
     tmpfile_hash,
+    tmpfile_formula_terms
 ] = tmpfiles
 
 

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -1361,12 +1361,16 @@ class read_writeTest(unittest.TestCase):
         self.assertTrue(g.equals(f))
 
     def test_differing_formula_terms(self):
+        # Read in example field with shape (1, 10, 9)
         f = cfdm.example_field(1)
         
+        # Write dummy file with original field and a slice.
         cfdm.write([f, f[0, 1:]], tmpfile_formula_terms)
 
+        # Read file back in.
         g = cfdm.read(tmpfile_formula_terms)
 
+        # Check file and slice are the same shape.
         self.assertTrue(g[1].equals(f[0, 1:], verbose=True))
 
 

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -36,7 +36,7 @@ tmpfiles.append(tempfile.mkstemp("#test_read_write.nc", dir=os.getcwd())[1])
     tmpfile0,
     tmpfile1,
     tmpfile_hash,
-    tmpfile_formula_terms
+    tmpfile_formula_terms,
 ] = tmpfiles
 
 

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -23,9 +23,10 @@ tmpfiles = [
     tempfile.mkstemp("_test_read_write.nc", dir=os.getcwd())[1]
     for i in range(n_tmpfiles)
 ]
-tmpfiles.append(tempfile.mkstemp("#test_read_write.nc", dir=os.getcwd())[1])
+tmpfiles.insert(0, tempfile.mkstemp("#test_read_write.nc", dir=os.getcwd())[1])
 
 [
+    tmpfile_hash,
     tmpfile,
     tmpfileh,
     tmpfileh2,
@@ -35,8 +36,6 @@ tmpfiles.append(tempfile.mkstemp("#test_read_write.nc", dir=os.getcwd())[1])
     tmpfilec3,
     tmpfile0,
     tmpfile1,
-    tmpfile_hash,
-    tmpfile_formula_terms,
 ] = tmpfiles
 
 
@@ -1360,18 +1359,22 @@ class read_writeTest(unittest.TestCase):
         g = cfdm.read(tmpfile_hash)[0]
         self.assertTrue(g.equals(f))
 
-    def test_differing_formula_terms(self):
+    def test_write_differing_formula_terms(self):
+        """Test cfdm.write for differing formula terms."""
         # Read in example field with shape (1, 10, 9)
-        f = cfdm.example_field(1)
-        
-        # Write dummy file with original field and a slice.
-        cfdm.write([f, f[0, 1:]], tmpfile_formula_terms)
+        f = self.f1
 
-        # Read file back in.
-        g = cfdm.read(tmpfile_formula_terms)
+        # Write dummy file with original field and a slice
+        f01 = [f, f[0, 1:]]
+        cfdm.write(f01, tmpfile)
 
-        # Check file and slice are the same shape.
-        self.assertTrue(g[1].equals(f[0, 1:], verbose=True))
+        # Read file back in
+        g01 = cfdm.read(tmpfile)
+
+        # Check the original fields are the same as the
+        # written-then-read fields.
+        for a, b in zip(f01, g01):
+            self.assertTrue(b.equals(a))
 
 
 if __name__ == "__main__":

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -1359,6 +1359,15 @@ class read_writeTest(unittest.TestCase):
         g = cfdm.read(tmpfile_hash)[0]
         self.assertTrue(g.equals(f))
 
+    def test_differing_formula_terms(self):
+        f = cfdm.example_field(1)
+        
+        cfdm.write([f, f[0, 1:]], tmpfile_formula_terms)
+
+        g = cfdm.read(tmpfile_formula_terms)
+
+        self.assertTrue(g[1].equals(f[0, 1:], verbose=True))
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())


### PR DESCRIPTION
Fixes #380 