### PR TITLE
Fix aggregation unlimited netCDF dimensions

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -4,8 +4,8 @@ Version NEXTVERSION
 **2026-03-??**
 
 * Fix bug in `cfdm.write` to correctly create unlimited aggregation
-  dimensions that correposend to unlimited normal dimensions
-  (https://github.com/NCAS-CMS/cfdm/pull/???)
+  dimensions that correspond to unlimited normal dimensions
+  (https://github.com/NCAS-CMS/cfdm/pull/387)
 * Fix bug in `cfdm.write` when writing identical coordinates that have
   different ``formula_terms``
   (https://github.com/NCAS-CMS/cfdm/issues/380). New unit test added.

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,6 +3,9 @@ Version NEXTVERSION
 
 **2026-03-??**
 
+* Fix bug in `cfdm.write` to correctly create unlimited aggregation
+  dimensions that correposend to unlimited normal dimensions
+  (https://github.com/NCAS-CMS/cfdm/pull/???)
 * Fix bug in `cfdm.write` when writing identical coordinates that have
   different ``formula_terms``
   (https://github.com/NCAS-CMS/cfdm/issues/380). New unit test added.

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -6344,10 +6344,6 @@ class NetCDFWrite(IOWrite):
 
         map_ncdimensions = tuple(map_ncdimensions)
 
-        #        # Write the fragment array variable to the netCDF dataset
-        #        if ncdimensions[0].startswith('time'):
-        #            chunking=(False, (f_map.shape[0], f_map.shape[1] * 85*12))
-
         feature_ncvar = self._cfa_write_fragment_array_variable(
             f_map,
             aggregated_data.get(feature, f"fragment_{feature}"),
@@ -6373,9 +6369,6 @@ class NetCDFWrite(IOWrite):
                 if cfa_ncdim not in all_dimensions:
                     # Create a new fragment array dimension
                     unlimited = ncdim in all_unlimited_dimensions
-                    # unlimited = ncdim in g[
-                    #    "unlimited_dimensions"
-                    # ] and ncdim.startswith("time")
                     self._write_dimension(
                         cfa_ncdim, None, unlimited=unlimited, size=size
                     )
@@ -6384,10 +6377,7 @@ class NetCDFWrite(IOWrite):
 
             location_ncdimensions = tuple(location_ncdimensions)
 
-            #            # Write the fragment array variable to the netCDF dataset
-            #            if ncdimensions[0].startswith('time'):
-            #                chunking = (False, ((85*12,) + f_uris.shape[1:]))
-            #            else:
+            # Write the fragment array variable to the netCDF dataset
             chunking = None
             feature_ncvar = self._cfa_write_fragment_array_variable(
                 f_uris,
@@ -6432,9 +6422,12 @@ class NetCDFWrite(IOWrite):
             unique_value_ncdimensions = []
             for ncdim, size in zip(ncdimensions, f_unique_value.shape):
                 cfa_ncdim = f"a_{ncdim}"
-                if cfa_ncdim not in g["dimensions"]:
+                if cfa_ncdim not in all_dimensions:
                     # Create a new fragment array dimension
-                    self._write_dimension(cfa_ncdim, None, size=size)
+                    unlimited = ncdim in all_unlimited_dimensions
+                    self._write_dimension(
+                        cfa_ncdim, None, unlimited=unlimited, size=size
+                    )
 
                 unique_value_ncdimensions.append(cfa_ncdim)
 


### PR DESCRIPTION
Fix bug in `cfdm.write` to correctly create unlimited aggregation dimensions that correspond to unlimited normal dimensions