### PR TITLE
Fix bug in `cfdm.write` when writing numpy scalars as Zarr attributes

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -5,6 +5,8 @@ Version NEXTVERSION
 
 * Fix bug in `cfdm.read` that prevented some OPeNDAP URLS being read
   (https://github.com/NCAS-CMS/cfdm/issues/406)
+* Fix bug in `cfdm.write` when writing numpy scalars as Zarr
+  attribtues (https://github.com/NCAS-CMS/cfdm/issues/408)
 
 Version 1.13.1.0
 ----------------

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -6,7 +6,7 @@ Version NEXTVERSION
 * Fix bug in `cfdm.read` that prevented some OPeNDAP URLS being read
   (https://github.com/NCAS-CMS/cfdm/issues/406)
 * Fix bug in `cfdm.write` when writing numpy scalars as Zarr
-  attribtues (https://github.com/NCAS-CMS/cfdm/issues/408)
+  attributes (https://github.com/NCAS-CMS/cfdm/issues/408)
 
 Version 1.13.1.0
 ----------------

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -394,11 +394,13 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
             case "netCDF4":
                 x.setncatts(attributes)
             case "zarr":
-                # `zarr` can't encode numpy arrays in the zarr.json
-                # file
+                # `zarr` can't encode numpy arrays nor numpy scalars
+                # in the zarr.json file
                 for attr, value in attributes.items():
                     if isinstance(value, np.ndarray):
                         attributes[attr] = value.tolist()
+                    elif isinstance(value, np.generic):
+                        attributes[attr] = value.item()
 
                 x.update_attributes(attributes)
 

--- a/cfdm/test/test_zarr.py
+++ b/cfdm/test/test_zarr.py
@@ -334,7 +334,7 @@ class read_writeTest(unittest.TestCase):
         self.assertEqual(len(f2), 1)
         self.assertTrue(f2[0].equals(f3[0]))
 
-    def test_zarr_write_np_attribute(self):
+    def test_zarr_write_numpy_attributes(self):
         """Test writing numpy attributes to Zarr."""
         f = self.f0.copy()
 

--- a/cfdm/test/test_zarr.py
+++ b/cfdm/test/test_zarr.py
@@ -340,7 +340,7 @@ class read_writeTest(unittest.TestCase):
 
         # Scalars
         x = 9
-        scalars =  (np.int32(x), np.int64(x), np.float32(x), np.float64(x))
+        scalars = (np.int32(x), np.int64(x), np.float32(x), np.float64(x))
         for i, scalar in enumerate(scalars):
             f.set_property(f"np_generic_{i}", scalar)
 
@@ -348,8 +348,7 @@ class read_writeTest(unittest.TestCase):
         y = [1, 2, 3]
         f.set_property("np_ndarray", np.array(y))
 
-#        tmpdir1 = 'tmpdir1.delme'
-        cfdm.write(f, tmpdir1)
+        cfdm.write(f, tmpdir1, fmt="ZARR3")
         f = cfdm.read(tmpdir1)
         self.assertEqual(len(f), 1)
 

--- a/cfdm/test/test_zarr.py
+++ b/cfdm/test/test_zarr.py
@@ -8,6 +8,7 @@ import unittest
 
 faulthandler.enable()  # to debug seg faults and timeouts
 
+import numpy as np
 import zarr
 
 import cfdm
@@ -332,6 +333,31 @@ class read_writeTest(unittest.TestCase):
         self.assertEqual(len(f2), len(f3))
         self.assertEqual(len(f2), 1)
         self.assertTrue(f2[0].equals(f3[0]))
+
+    def test_zarr_write_np_attribute(self):
+        """Test writing numpy attributes to Zarr."""
+        f = self.f0.copy()
+
+        # Scalars
+        x = 9
+        scalars =  (np.int32(x), np.int64(x), np.float32(x), np.float64(x))
+        for i, scalar in enumerate(scalars):
+            f.set_property(f"np_generic_{i}", scalar)
+
+        # ndarrays
+        y = [1, 2, 3]
+        f.set_property("np_ndarray", np.array(y))
+
+#        tmpdir1 = 'tmpdir1.delme'
+        cfdm.write(f, tmpdir1)
+        f = cfdm.read(tmpdir1)
+        self.assertEqual(len(f), 1)
+
+        f = f[0]
+        for i in range(len(scalars)):
+            self.assertEqual(f.get_property(f"np_generic_{i}"), x)
+
+        self.assertTrue(np.allclose(f.get_property("np_ndarray"), y))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #408