### PR TITLE
Replace obsolete kwargs to `_add_message` & pre-release lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,22 +28,22 @@ repos:
       - id: black
         language_version: python3
 
-  # Also format docstrings in a consistent way, on top of 'black' requirements
-  # with the aim to auto-correct towards the Google docstring format (see
-  # https://google.github.io/styleguide/pyguide.html#381-docstrings) as much
-  # as possible (see https://github.com/myint/docformatter for docs, with
-  # configuration as below)
-#  - repo: https://github.com/myint/docformatter
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.8
-    hooks:
-      - id: docformatter
-        # These arguments act as the configuration for docformatter. They:
-        # * make docformatter auto-format in-place if not compliant;
-        # * ensure there is a blank line after the final non-empty line;
-        # * wraps both summary and description at 72 characters (the latter
-        #   by default).
-        args: [--in-place, --blank, --wrap-summaries=72]
+  # # Also format docstrings in a consistent way, on top of 'black' requirements
+  # # with the aim to auto-correct towards the Google docstring format (see
+  # # https://google.github.io/styleguide/pyguide.html#381-docstrings) as much
+  # # as possible (see https://github.com/myint/docformatter for docs, with
+  # # configuration as below)
+  # #  - repo: https://github.com/myint/docformatter
+  # - repo: https://github.com/PyCQA/docformatter
+  #   rev: v1.7.8
+  #   hooks:
+  #     - id: docformatter
+  #       # These arguments act as the configuration for docformatter. They:
+  #       # * make docformatter auto-format in-place if not compliant;
+  #       # * ensure there is a blank line after the final non-empty line;
+  #       # * wraps both summary and description at 72 characters (the latter
+  #       #   by default).
+  #       args: [--black, --in-place, --blank, --wrap-summaries=72]
 
   # Check the docstrings conforms to Google docstring format as much as can
   # be detected by the 'pydocstyle' checker

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
   # configuration as below)
 #  - repo: https://github.com/myint/docformatter
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.6
+    rev: v1.7.8
     hooks:
       - id: docformatter
         # These arguments act as the configuration for docformatter. They:

--- a/cfdm/conformance/checker.py
+++ b/cfdm/conformance/checker.py
@@ -28,8 +28,7 @@ class FieldChecker(Report):
     # --------------------- New methods from PR #373 ------------------------
 
     def _check_standard_name_modifier(self, standard_name):
-        """True if a (computed) standard name has a valid modifier, or
-        none.
+        """True if a valid modifier or none for a (computed) standard name.
 
         Also return the standard name with modifiers stripped, as the second
         tuple item.

--- a/cfdm/conformance/datamodel.py
+++ b/cfdm/conformance/datamodel.py
@@ -2,6 +2,7 @@ class NonConformanceCase:
     """Describes a case of CF Conventions non-conformance."""
 
     def __init__(self, reason, code):
+        """**Initialisation**"""
         if (
             not reason
             or not code
@@ -42,6 +43,7 @@ class AttributeNonConformance:
         variables=None,
         dimensions=None,
     ):
+        """**Initialisation**"""
         if not name and not isinstance(name, str):
             raise ValueError("Attribute name (a string) is required.")
 
@@ -145,6 +147,7 @@ class DimensionNonConformance:
     """Non-conformances related to a netCDF dimension."""
 
     def __init__(self, name, size=None, non_conformances=None, variables=None):
+        """**Initialisation**"""
         if not name and not isinstance(name, str):
             raise ValueError("Dimension name (a string) is required.")
 
@@ -231,6 +234,7 @@ class VariableNonConformance:
         attributes=None,
         dimensions=None,
     ):
+        """**Initialisation**"""
         if not name and not isinstance(name, str):
             raise ValueError("Variable name (a string) is required.")
 

--- a/cfdm/conformance/datamodel.py
+++ b/cfdm/conformance/datamodel.py
@@ -73,18 +73,15 @@ class AttributeNonConformance:
         self.dimensions = dimensions or []
 
     def set_variables(self, variables):
-        """Set variables associated with the attribute's non-
-        compliance."""
+        """Set variables associated with attribute's non-compliance."""
         self.variables = variables
 
     def set_dimensions(self, dimensions):
-        """Set dimensions associated with the attribute's non-
-        compliance."""
+        """Set dimensions associated with attribute's non-compliance."""
         self.dimensions = dimensions
 
     def add_variable(self, var):
-        """Append a variable relating to the attribute's non-
-        compliance."""
+        """Append a variable relating to attribute's non-compliance."""
         # Ensure attribute has a list to store objects
         if not hasattr(self, "variables"):
             self.variables = []
@@ -94,8 +91,7 @@ class AttributeNonConformance:
             self.variables.append(var)
 
     def add_dimension(self, dim):
-        """Append a dimension relating to the attribute's non-
-        compliance."""
+        """Append a dimension relating to attribute's non-compliance."""
         self.dimensions.append(dim)
 
     def todict(self):
@@ -174,13 +170,11 @@ class DimensionNonConformance:
         self.variables = variables or []
 
     def set_variables(self, variables):
-        """Set variables associated with the dimension's non-
-        compliance."""
+        """Set variables associated with dimension's non-compliance."""
         self.variables = variables
 
     def add_variable(self, var):
-        """Append a variable relating to the dimension's non-
-        compliance."""
+        """Append a variable relating to dimension's non-compliance."""
         self.variables.append(var)
         return var
 
@@ -252,18 +246,15 @@ class VariableNonConformance:
         return None
 
     def set_attributes(self, attributes):
-        """Set attributes associated with the variable's non-
-        compliance."""
+        """Set attributes associated with variable's non-compliance."""
         self.attributes = attributes
 
     def set_dimensions(self, dimensions):
-        """Set dimensions associated with the variable's non-
-        compliance."""
+        """Set dimensions associated with variable's non-compliance."""
         self.dimensions = dimensions
 
     def add_attribute(self, attr):
-        """Append an attribute relating to the variable's non-
-        compliance."""
+        """Append an attribute relating to variable's non-compliance."""
         # Check if already there first
         for attrib in self.attributes:
             if attrib.equals(attr):
@@ -273,13 +264,11 @@ class VariableNonConformance:
         return attr
 
     def add_dimension(self, dim):
-        """Append a dimension relating to the variable's non-
-        compliance."""
+        """Append a dimension relating to variable's non-compliance."""
         self.dimensions.append(dim)
 
     def todict(self):
-        """Report the variable non-compliance in dictionary fragment
-        form.
+        """Report the variable non-compliance in dictionary form.
 
         For a more concise dict with class-based value representation,
         see repr().

--- a/cfdm/conformance/reporting.py
+++ b/cfdm/conformance/reporting.py
@@ -24,6 +24,7 @@ class Report:
     """
 
     def __init__(self):
+        """**Initialisation**"""
         self.read_vars = {}  # intended to be overloaded by NetCDFRead
 
         # Reporting stores

--- a/cfdm/conformance/reporting.py
+++ b/cfdm/conformance/reporting.py
@@ -16,8 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class Report:
-    """Reporting of CF Compliance non-conformance for field creation
-    from netCDF.
+    """CF Conventions conformance report for field creation from netCDF.
 
     Holds methods for reporting about non-compliance.
 
@@ -32,8 +31,7 @@ class Report:
         self.variable_report = []
 
     def _process_dimension_sizes(self, ncvar):
-        """Process dimension sizes to report in issues with
-        dimensions."""
+        """Process dimension sizes to report in issues with dimensions."""
         # NOTE: not actually used yet, but will be when issues with Dimensions
         # are incorporated into the new Conformance Data Model.
         g = self.read_vars
@@ -262,8 +260,7 @@ class Report:
                 existing_attr.add_variable(ncvar_nc)
 
     def _get_variable_non_compliance_report(self, var):
-        """Return if present a Variable NonCompliance from the
-        report."""
+        """Return if present a Variable NonCompliance from the report."""
         for variable in self.variable_report:
             if variable.name == var:
                 return variable
@@ -271,8 +268,7 @@ class Report:
         return False
 
     def _get_variable_non_compliance(self, var):
-        """Return an existing else new Variable NonCompliance for a
-        variable."""
+        """Return the Variable NonCompliance for a variable."""
         var_nc = self._get_variable_non_compliance_report(var)
 
         if not var_nc:

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -24,8 +24,7 @@ _STD_NAME_CURRENT_XML_URL = (
 
 
 def _extract_names_from_xml(snames_xml, include_aliases):
-    """Extract standard names from a valid Standard Name Table XML
-    document.
+    """Extract all names from a valid Standard Name Table XML document.
 
     Whether or not to include registered aliases is dependent on the value
     of the `include_aliases` flag.
@@ -73,8 +72,7 @@ def _extract_names_from_xml(snames_xml, include_aliases):
 
 @lru_cache
 def get_all_current_standard_names(include_aliases=False):
-    """Get a list of all CF Standard Names from the current version
-    table.
+    """Get list of all CF Standard Names from the current table.
 
     Entries are always returned from the current table. By default aliases
     are not included in the output but can also be included by setting the

--- a/cfdm/read_write/netcdf/checker.py
+++ b/cfdm/read_write/netcdf/checker.py
@@ -99,7 +99,7 @@ class NetCDFCheckerMixin(Report):
                 bounds_ncvar,
                 message=message,
                 attribute=attribute,
-                variable=coord_ncvar,
+                direct_parent_ncvar=coord_ncvar,
             )
             return False
 
@@ -116,7 +116,7 @@ class NetCDFCheckerMixin(Report):
                     message=incorrect_dimensions,
                     attribute=attribute,
                     dimensions=g["variable_dimensions"][bounds_ncvar],
-                    variable=coord_ncvar,
+                    direct_parent_ncvar=coord_ncvar,
                 )
                 ok = False
 
@@ -127,7 +127,7 @@ class NetCDFCheckerMixin(Report):
                 message=incorrect_dimensions,
                 attribute=attribute,
                 dimensions=g["variable_dimensions"][bounds_ncvar],
-                variable=coord_ncvar,
+                direct_parent_ncvar=coord_ncvar,
             )
             ok = False
 
@@ -181,7 +181,7 @@ class NetCDFCheckerMixin(Report):
                 node_ncvar,
                 message=message,
                 attribute=attribute,
-                variable=field_ncvar,
+                direct_parent_ncvar=field_ncvar,
             )
             return False
 
@@ -196,7 +196,7 @@ class NetCDFCheckerMixin(Report):
                     "not in node_coordinates",
                 ),
                 attribute=attribute,
-                variable=field_ncvar,
+                direct_parent_ncvar=field_ncvar,
             )
             ok = False
 
@@ -1406,7 +1406,7 @@ class NetCDFCheckerMixin(Report):
                             "is incorrectly formatted",
                         ),
                         attribute=attribute,
-                        variable=coord_ncvar,
+                        direct_parent_ncvar=coord_ncvar,
                     )
 
                 for x in parsed_bounds_formula_terms:
@@ -1423,7 +1423,7 @@ class NetCDFCheckerMixin(Report):
                                 "is incorrectly formatted",
                             ),
                             attribute=bounds_attribute,
-                            variable=coord_ncvar,
+                            direct_parent_ncvar=coord_ncvar,
                         )
                         continue
 
@@ -1439,7 +1439,7 @@ class NetCDFCheckerMixin(Report):
                             ncvar,
                             message=message,
                             attribute=bounds_attribute,
-                            variable=coord_ncvar,
+                            direct_parent_ncvar=coord_ncvar,
                         )
                         continue
 
@@ -1452,7 +1452,7 @@ class NetCDFCheckerMixin(Report):
                                 "has incompatible terms",
                             ),
                             attribute=bounds_attribute,
-                            variable=coord_ncvar,
+                            direct_parent_ncvar=coord_ncvar,
                         )
                         continue
 
@@ -1476,7 +1476,7 @@ class NetCDFCheckerMixin(Report):
                                     "coordinate variable",
                                 ),
                                 attribute=bounds_attribute,
-                                variable=coord_ncvar,
+                                direct_parent_ncvar=coord_ncvar,
                             )
                             continue
 
@@ -1490,7 +1490,7 @@ class NetCDFCheckerMixin(Report):
                             ),
                             attribute=bounds_attribute,
                             dimensions=dimensions,
-                            variable=coord_ncvar,
+                            direct_parent_ncvar=coord_ncvar,
                         )
                         continue
                     # WRONG - need to account for char arrays:
@@ -1504,7 +1504,7 @@ class NetCDFCheckerMixin(Report):
                             ),
                             attribute=bounds_attribute,
                             dimensions=dimensions,
-                            variable=coord_ncvar,
+                            direct_parent_ncvar=coord_ncvar,
                         )
                         continue
 
@@ -1522,7 +1522,7 @@ class NetCDFCheckerMixin(Report):
                             "has incompatible terms",
                         ),
                         attribute=bounds_attribute,
-                        variable=coord_ncvar,
+                        direct_parent_ncvar=coord_ncvar,
                     )
 
             else:
@@ -1575,7 +1575,7 @@ class NetCDFCheckerMixin(Report):
                                 "has no bounds",
                             ),
                             attribute=attribute,
-                            variable=coord_ncvar,
+                            direct_parent_ncvar=coord_ncvar,
                         )
 
     def _missing_variable(self, ncvar, message0):
@@ -1931,7 +1931,7 @@ class NetCDFCheckerMixin(Report):
                 mesh_ncvar,
                 message=message,
                 attribute={f"{location_index_set_ncvar}:mesh": mesh_ncvar},
-                variable=location_index_set_ncvar,
+                direct_parent_ncvar=location_index_set_ncvar,
             )
             ok = False
         elif mesh_ncvar not in g["mesh"]:
@@ -2044,7 +2044,7 @@ class NetCDFCheckerMixin(Report):
                 mesh_ncvar,
                 message=message,
                 attribute={f"{location_index_set_ncvar}:mesh": mesh_ncvar},
-                variable=location_index_set_ncvar,
+                direct_parent_ncvar=location_index_set_ncvar,
             )
             ok = False
         elif mesh_ncvar not in g["mesh"]:
@@ -2216,7 +2216,7 @@ class NetCDFCheckerMixin(Report):
                 parent_ncvar,
                 connectivity_ncvar,
                 message=(f"{connectivity_attr} attribute", "is missing"),
-                variable=mesh_ncvar,
+                direct_parent_ncvar=mesh_ncvar,
             )
             ok = False
             return ok
@@ -2232,7 +2232,7 @@ class NetCDFCheckerMixin(Report):
                 attribute={
                     f"{mesh_ncvar}:{connectivity_attr}": connectivity_ncvar
                 },
-                variable=mesh_ncvar,
+                direct_parent_ncvar=mesh_ncvar,
             )
             ok = False
             return ok

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -159,6 +159,7 @@ class NetCDFRead(IORead, FieldChecker, NetCDFCheckerMixin):
     }
 
     def __init__(self, implementation=None):
+        """**Initialisation**"""
         FieldChecker.__init__(self)
         self.implementation = implementation  # from IORead
 

--- a/cfdm/test/test_compliance_checking.py
+++ b/cfdm/test/test_compliance_checking.py
@@ -35,8 +35,7 @@ atexit.register(_remove_tmpfiles)
 def _create_noncompliant_names_fields(
     compliant_field, temp_file, ugrid_case=False
 ):
-    """Create a copy of a field with bad standard names on all
-    variables."""
+    """Create a field copy with bad standard names across variables."""
     cfdm.write(compliant_field, temp_file)
 
     with Dataset(temp_file, "r+") as nc:
@@ -246,8 +245,7 @@ class ComplianceCheckingTest(unittest.TestCase):
         )
 
     def test_get_all_current_standard_names(self):
-        """Test the `conformance.get_all_current_standard_names`
-        function."""
+        """Test `conformance.get_all_current_standard_names` function."""
         # First check the URL used is actually available in case of issues
         # arising in case GitHub endpoints go down
         sn_xml_url = cfdm.conformance._STD_NAME_CURRENT_XML_URL
@@ -315,8 +313,7 @@ class ComplianceCheckingTest(unittest.TestCase):
         self.assertEqual(dc_output, {"CF version": self.expected_cf_version})
 
     def test_standard_names_validation_noncompliant_field(self):
-        """Test compliance checking on a non-compliant non-UGRID
-        field."""
+        """Test non-compliant non-UGRID field compliance checking."""
         f = self.bad_snames_general_field
         dc_output = f.dataset_compliance()
 

--- a/cfdm/test/test_compliance_checking.py
+++ b/cfdm/test/test_compliance_checking.py
@@ -45,8 +45,6 @@ def _create_noncompliant_names_fields(
         # Process mesh-related variables for UGRID special case (see below)
         mesh_related = set()
         if "mesh" in nc.variables:
-            mesh = nc.variables["mesh"]
-
             # Collect all variables referenced by the mesh variable
             vars_collection = ["mesh"]
 


### PR DESCRIPTION
Fixes an issue from a partially bodged merge conflict resolution in #373, namely that some of the new & old calls to `_add_message` were using the old API where `variable` was a valid keyword - in that PR it was updated to the more informative `direct_parent_ncvar` (see [this commit](https://github.com/NCAS-CMS/cfdm/pull/373/changes/11de20778976fb50d7e0cf547519da6ca61c82ce) which outlines the change to the method itself) but in resolving conflicts in that PR somehow some of the old code was left in there, resulting in errors such as:

```pytb
Traceback (most recent call last):
  File "/home/slb93/git-repos/cf-python/docs/source/test_tutorial/../tutorial.py", line 6, in <module>
    y = cf.read('*.nc')
  File "/home/slb93/git-repos/cfdm/cfdm/decorators.py", line 171, in verbose_override_wrapper
    return method_with_verbose_kwarg(*args, **kwargs)
  File "/home/slb93/git-repos/cf-python/cf/read_write/read.py", line 545, in __new__
    return super().__new__(**kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/slb93/git-repos/cfdm/cfdm/decorators.py", line 171, in verbose_override_wrapper
    return method_with_verbose_kwarg(*args, **kwargs)
  File "/home/slb93/git-repos/cfdm/cfdm/read_write/read.py", line 328, in __new__
    self._read(dataset)
    ~~~~~~~~~~^^^^^^^^^
  File "/home/slb93/git-repos/cf-python/cf/read_write/read.py", line 689, in _read
    super()._read(dataset)
    ~~~~~~~~~~~~~^^^^^^^^^
  File "/home/slb93/git-repos/cfdm/cfdm/read_write/read.py", line 669, in _read
    self.dataset_contents = self.netcdf_read(dataset)
                            ~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/slb93/git-repos/cfdm/cfdm/decorators.py", line 171, in verbose_override_wrapper
    return method_with_verbose_kwarg(*args, **kwargs)
  File "/home/slb93/git-repos/cfdm/cfdm/read_write/netcdf/netcdfread.py", line 2482, in read
    field_or_domain = self._create_field_or_domain(
        ncvar, domain=domain
    )
  File "/home/slb93/git-repos/cfdm/cfdm/read_write/netcdf/netcdfread.py", line 4752, in _create_field_or_domain
    self._check_formula_terms(
    ~~~~~~~~~~~~~~~~~~~~~~~~~^
        field_ncvar,
        ^^^^^^^^^^^^
    ...<2 lines>...
        z_ncdim=g["variable_dimensions"][coord_ncvar][0],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/slb93/git-repos/cfdm/cfdm/read_write/netcdf/checker.py", line 1484, in _check_formula_terms
    self._add_message(
    ~~~~~~~~~~~~~~~~~^
        field_ncvar,
        ^^^^^^^^^^^^
    ...<7 lines>...
        variable=coord_ncvar,
        ^^^^^^^^^^^^^^^^^^^^^
    )
    ^
TypeError: Report._add_message() got an unexpected keyword argument 'variable'
```

downstream in cf-python code.

Note testing on the conformance checking will be extended in coverage etc. in future - this ideally would have been caught in the cfdm test suite pre-release, but at present it isn't being detected and only through the cf-python tutorial code testing did we notice it.

Also includes pre-bug-fix-release linting, mostly to fix docstring line wrapping though note like in the cf-python pre-commit config. I've disabled `docsformatter` which is very strict and would change most Python modules in the codebase - so is too much clutter for now. (We can configure and re-enable in future.)