### PR TITLE
Add dotfile cache support for standard names retrieval

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,16 @@
+Version ???
+-----------
+
+**2026-??-??**
+
+* Introduce use of cache files under `.cf/standard_names.pickle*` to
+  improve performance of CF compliance checking
+  (https://github.com/NCAS-CMS/cfdm/pull/411)
+* Stop inaccessiblity of standard names table resource from causing
+  `cfdm.read` to error (https://github.com/NCAS-CMS/cfdm/pull/411)
+
+----
+
 Version 1.13.2.1
 ----------------
 

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,8 +3,8 @@ Version ???
 
 **2026-??-??**
 
-* Introduce use of cache files under `.cf/standard_names.pickle*` to
-  improve performance of CF compliance checking
+* Introduce use of cache files stored as `~/.cf/standard_names*.pickle`
+  to improve performance of CF compliance checking
   (https://github.com/NCAS-CMS/cfdm/pull/411)
 * Stop inaccessiblity of standard names table resource from causing
   `cfdm.read` to error (https://github.com/NCAS-CMS/cfdm/pull/411)

--- a/cfdm/__init__.py
+++ b/cfdm/__init__.py
@@ -172,13 +172,6 @@ from .examplefield import example_field, example_fields, example_domain
 
 from .abstract import Container
 
-# For now only intended for internal use but used in testing, so need exposing:
-from .conformance import (
-    get_all_current_standard_names,
-    _extract_names_from_xml,
-    _STD_NAME_CURRENT_XML_URL,
-)
-
 # --------------------------------------------------------------------
 # Set up basic logging for the full project with a root logger
 # --------------------------------------------------------------------

--- a/cfdm/conformance/__init__.py
+++ b/cfdm/conformance/__init__.py
@@ -5,11 +5,11 @@ from .datamodel import (
     NonConformanceCase,
     VariableNonConformance,
 )
+
+# Allow users to access TODO though not yet advertised (i.e. in the API ref)
+# - wait until conformance work is more mature before doing this
 from .standardnames import (
     get_all_current_standard_names,
-    # Intended for internal use but used in testing, so need exposing:
-    _extract_names_from_xml,
-    _STD_NAME_CURRENT_XML_URL,
 )
 
 # Eventually structure as with individual modules per class, something like:

--- a/cfdm/conformance/checker.py
+++ b/cfdm/conformance/checker.py
@@ -89,6 +89,11 @@ class FieldChecker(Report):
         one parent variable (though the parent can be set at the variable
         itself should no parent exist or be relevant).
 
+        The checks will only run if the XML which encodes the table of
+        names is accessible, else the exception
+        `StandardNameTableUnavailableError` will be caught and all
+        validation logic bypassing, returning `None`.
+
         .. versionadded:: 1.13.2.0
 
         :Parameters:
@@ -178,9 +183,9 @@ class FieldChecker(Report):
                 name(s) exist but at least one is invalid
                 according to those checks, and `None` means that
                 either no (computed_)standard_name was found,
-                or that the checking has been skipped (only in
-                cases where the Standard Names Table cannot be
-                accessed).
+                or that the checking has been skipped (the latter
+                only in cases where the Standard Names Table
+                cannot be accessed).
 
         """
         if check_is_in_custom_list and check_is_in_table:

--- a/cfdm/conformance/checker.py
+++ b/cfdm/conformance/checker.py
@@ -6,7 +6,10 @@ import numpy as np
 
 from ..functions import is_log_level_debug
 from .reporting import Report
-from .standardnames import get_all_current_standard_names
+from .standardnames import (
+    StandardNameTableUnavailableError,
+    get_all_current_standard_names,
+)
 
 
 class FieldChecker(Report):
@@ -173,15 +176,13 @@ class FieldChecker(Report):
                 standard name(s) exist and are (all) valid against
                 the configured checks, `False` means standard
                 name(s) exist but at least one is invalid
-                according to those checks, and `None` means no
-                (computed_)standard_name was found.
+                according to those checks, and `None` means that
+                either no (computed_)standard_name was found,
+                or that the checking has been skipped (only in
+                cases where the Standard Names Table cannot be
+                accessed).
 
         """
-        debug = is_log_level_debug(logger)
-
-        if debug:
-            logger.debug(f"Running _check_standard_names() for: {ncvar}")
-
         if check_is_in_custom_list and check_is_in_table:
             raise ValueError(
                 "Can't set both 'check_is_in_custom_list' and "
@@ -189,6 +190,18 @@ class FieldChecker(Report):
                 "to check a subset of the full table hence renders the "
                 "latter redundant - set it to False with a custom list."
             )
+
+        # To short circuit checking early when the table can't be accessed
+        if check_is_in_table:
+            try:
+                all_current_standard_names = get_all_current_standard_names()
+            except StandardNameTableUnavailableError:
+                return
+
+        debug = is_log_level_debug(logger)
+
+        if debug:
+            logger.debug(f"Running _check_standard_names() for: {ncvar}")
 
         any_sn_found = False
         invalid_sn_found = False
@@ -269,7 +282,7 @@ class FieldChecker(Report):
             # 5. Check, if requested, if string is in the list of valid names
             elif (
                 check_is_in_table
-                and sn_value not in get_all_current_standard_names()
+                and sn_value not in all_current_standard_names
             ):
                 invalid_sn_found = True
                 if self.read_vars["_noncompliance_report"]:
@@ -291,7 +304,9 @@ class FieldChecker(Report):
                 )
 
         # Three possible return signatures to cover existence and validity:
-        if not any_sn_found:  # no (computed_)standard_name found
+        if (
+            not any_sn_found
+        ):  # no (computed_)standard_name found (or checks bypassed)
             return
         elif invalid_sn_found:  # found at least one invalid standard name
             return False

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import os
 import pickle
+import sys
 import xml.etree.ElementTree as ET
 from functools import lru_cache
 
@@ -29,8 +30,10 @@ DEFAULT_TIMEOUT_SECONDS = 5
 
 # Cache config.
 CACHE_DIR = ".cf"
-CACHE_PICKLE_FILENAME_NOALIASES = "standard_names.pickle"
-CACHE_PICKLE_FILENAME_WITHALIASES = "standard_names_with_aliases.pickle"
+# Filenames exclude the ".pickle" extension which is added later
+CACHE_PICKLE_FILENAME_NOALIASES = "standard_names"
+CACHE_PICKLE_FILENAME_WITHALIASES = "standard_names_with_aliases"
+
 CACHE_FORMAT_VERSION = 1
 CACHE_MAX_AGE_DAYS = 30
 
@@ -150,6 +153,12 @@ def _get_cache_file_path(include_aliases=False):
     else:
         filename = CACHE_PICKLE_FILENAME_NOALIASES
 
+    # Add Python version before extension in form without dots e.g. '39', '312'
+    # where there won't be ambiguity as to what part is major and minor given
+    # unlikely to get to double-digit major version any time soon!
+    python_version = f"{sys.version_info.major}{sys.version_info.minor}"
+    filename += f"_{python_version}.pickle"
+
     return os.path.join(cache_dir, filename)
 
 
@@ -263,7 +272,7 @@ def _load_standard_names_from_dotfile(include_aliases=False):
 
 @lru_cache
 def get_all_current_standard_names(include_aliases=False):
-    """Get list of all CF Standard Names from the current table.
+    """Get the set of all CF Standard Names from the current table.
 
     Entries are always returned from the current table. By default aliases
     are not included in the output but can also be included by setting the
@@ -273,7 +282,7 @@ def get_all_current_standard_names(include_aliases=False):
     canonical location stored under the repository
     `github.com/cf-convention/cf-convention.github.io/`, and
     raises the exception `StandardNameTableUnavailableError` if it is
-    not accessible until timeout.
+    not accessible by timeout.
 
     .. versionadded:: 1.13.2.0
 

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -221,5 +221,7 @@ def get_all_current_standard_names(include_aliases=False):
             "Downloaded CF standard name table is not valid XML and cannot be parsed."
         ) from exc
 
-    _cache_standard_names_to_dotfile(names_set, include_aliases=False)
+    _cache_standard_names_to_dotfile(
+        names_set, include_aliases=include_aliases
+    )
     return names_set

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -155,8 +155,8 @@ def _get_cache_file_path(include_aliases=False):
 
 def _cache_standard_names_to_dotfile(
     standard_names,
+    table_version,
     include_aliases=False,
-    table_version=None,
 ):
     """Create a pickle cache of the frozenset of fetched standard names.
 
@@ -169,16 +169,15 @@ def _cache_standard_names_to_dotfile(
              given version of the table, including aliases if
              requested, to save to a new cache file.
 
+         table_version: `str`
+             The version of the standard names table of the XML
+             document, to register as metadata for the cache file.
+
          include_aliases: `bool`, optional
              Set to `True` if the file will cache standard names
              inclusive of standard name aliases, else and by
              default the cache file name is chosen to reflect
              that it does not include aliases.
-
-         table_version: `str` or `None`, optional
-             The version of the standard names table of the XML
-             document, to register as metadata for the cache file.
-             If `None`, as default, then do not register a version.
 
      :Returns:
 
@@ -345,8 +344,8 @@ def get_all_current_standard_names(include_aliases=False):
     table_version = _extract_table_version_from_xml(all_snames_xml)
     _cache_standard_names_to_dotfile(
         names_set,
+        table_version,
         include_aliases=include_aliases,
-        table_version=table_version,
     )
 
     return names_set

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -36,6 +36,7 @@ class StandardNameTableUnavailableError(Exception):
         )
         if reason is not None:
             message += f" Reason: {reason}"
+
         super().__init__(message)
 
 
@@ -92,6 +93,12 @@ def get_all_current_standard_names(include_aliases=False):
     Entries are always returned from the current table. By default aliases
     are not included in the output but can also be included by setting the
     `include_aliases` flag to `True`.
+
+    Relies on access to the XML which encodes the table of names from the
+    canonical location stored under the repository
+    `github.com/cf-convention/cf-convention.github.io/`, and
+    raises the exception `StandardNameTableUnavailableError` if it is
+    not accessible until timeout.
 
     .. versionadded:: 1.13.2.0
 

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -101,7 +101,7 @@ def _get_cache_file_path():
     return os.path.join(cache_dir, CACHE_PICKLE_FILENAME)
 
 
-def _cache_to_dotfile_standard_names(standard_names, include_aliases=False):
+def _cache_standard_names_to_dotfile(standard_names, include_aliases=False):
     """Create a pickle cache of the frozenset of fetched names."""
     cache_file = _get_cache_file_path()
 
@@ -111,8 +111,8 @@ def _cache_to_dotfile_standard_names(standard_names, include_aliases=False):
     return cache_file
 
 
-def _load_from_dotfile_with_standard_names(include_aliases=False):
-    """Load a pickle cache of the frozenset of fetched names."""
+def _load_standard_names_from_dotfile(include_aliases=False):
+    """Load a pickle cache of the frozenset of fetched names, or None on failure."""
     cache_file = _get_cache_file_path()
     print("CACHE IS AT:", cache_file)
     try:
@@ -120,7 +120,7 @@ def _load_from_dotfile_with_standard_names(include_aliases=False):
             return pickle.load(f)
     except (IOError, EOFError, pickle.UnpicklingError):
         # Cache doesn't exist or is corrupt
-        return False
+        return None
 
 
 @lru_cache
@@ -161,9 +161,7 @@ def get_all_current_standard_names(include_aliases=False):
 
     # First attempt to get a cached version from a pickle of the frozenset
     # of names that may have been fetched and stored at an earlier time
-    pickled_names = _load_from_dotfile_with_standard_names(
-        include_aliases=False
-    )
+    pickled_names = _load_standard_names_from_dotfile(include_aliases=False)
     if pickled_names:
         return pickled_names
 
@@ -202,5 +200,5 @@ def get_all_current_standard_names(include_aliases=False):
             "Downloaded CF standard name table is not valid XML and cannot be parsed."
         ) from exc
 
-    _cache_to_dotfile_standard_names(names_set, include_aliases=False)
+    _cache_standard_names_to_dotfile(names_set, include_aliases=False)
     return names_set

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 import pickle
@@ -30,6 +31,8 @@ DEFAULT_TIMEOUT = 5  # seconds
 CACHE_DIR = ".cf"
 CACHE_PICKLE_FILENAME_NOALIASES = "standard_names.pickle"
 CACHE_PICKLE_FILENAME_WITHALIASES = "standard_names_with_aliases.pickle"
+CACHE_FORMAT_VERSION = 1
+CACHE_MAX_AGE_DAYS = 30
 
 
 class StandardNameTableUnavailableError(Exception):
@@ -93,6 +96,12 @@ def _extract_names_from_xml(snames_xml, include_aliases):
     return frozenset(all_standard_names)
 
 
+def _extract_table_version_from_xml(snames_xml):
+    """TODO."""
+    root = ET.fromstring(snames_xml)
+    return root.findtext("version_number")
+
+
 def _get_cache_file_path(include_aliases=False):
     """TODO."""
     cache_dir = os.path.join(
@@ -111,12 +120,26 @@ def _get_cache_file_path(include_aliases=False):
     return os.path.join(cache_dir, filename)
 
 
-def _cache_standard_names_to_dotfile(standard_names, include_aliases=False):
+def _cache_standard_names_to_dotfile(
+    standard_names,
+    include_aliases=False,
+    table_version=None,
+):
     """Create a pickle cache of the frozenset of fetched names."""
     cache_file = _get_cache_file_path(include_aliases=include_aliases)
 
+    # Include some metadata with the frozen set of names, to allow us to detect if
+    # the dotfile is stale or of an old version
+    cache = {
+        "cache_format_version": CACHE_FORMAT_VERSION,
+        "standard_names": standard_names,
+        "include_aliases": include_aliases,
+        "table_version": table_version,
+        "cached_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+
     with open(cache_file, "wb") as f:
-        pickle.dump(standard_names, f, protocol=pickle.HIGHEST_PROTOCOL)
+        pickle.dump(cache, f, protocol=pickle.HIGHEST_PROTOCOL)
 
     logger.info(
         f"Cached set of fetched standard names to dotfile at {cache_file}"
@@ -126,20 +149,38 @@ def _cache_standard_names_to_dotfile(standard_names, include_aliases=False):
 
 
 def _load_standard_names_from_dotfile(include_aliases=False):
-    """Load a pickle cache of the frozenset of fetched names, or None on failure."""
+    """Load a pickled dotfile cache of standard names, or None if unavailable/stale."""
     cache_file = _get_cache_file_path(include_aliases=include_aliases)
 
     try:
         with open(cache_file, "rb") as f:
-            names = pickle.load(f)
-    except (IOError, EOFError, pickle.UnpicklingError):
-        # Cache doesn't exist or is corrupt
-        return None
+            cache = pickle.load(f)
+    except (
+        IOError,
+        EOFError,
+        pickle.UnpicklingError,
+    ):
+        return
+
+    if cache.get("cache_format_version") != CACHE_FORMAT_VERSION:
+        return
+
+    if cache.get("include_aliases") != include_aliases:
+        return
+
+    cached_at = datetime.datetime.fromisoformat(cache["cached_at"])
+
+    age = datetime.datetime.now(datetime.timezone.utc) - cached_at
+
+    if age > datetime.timedelta(days=CACHE_MAX_AGE_DAYS):
+        logger.info("Ignoring stale CF standard name cache.")
+        return
 
     logger.info(
         f"Loaded set of fetched standard names from dotfile at {cache_file}"
     )  # pragma: no cover
-    return names
+
+    return cache["standard_names"]
 
 
 @lru_cache
@@ -221,7 +262,12 @@ def get_all_current_standard_names(include_aliases=False):
             "Downloaded CF standard name table is not valid XML and cannot be parsed."
         ) from exc
 
+    # Successfully extracted set of all current names. Cache to dotfile for future use.
+    table_version = _extract_table_version_from_xml(all_snames_xml)
     _cache_standard_names_to_dotfile(
-        names_set, include_aliases=include_aliases
+        names_set,
+        include_aliases=include_aliases,
+        table_version=table_version,
     )
+
     return names_set

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -125,7 +125,7 @@ def _get_cache_file_path(include_aliases=False):
 
      :Parameters:
 
-         include_aliases: `bool`
+         include_aliases: `bool`, optional
              If `True`, return the path of the file which caches
              standard names inclusive of standard name aliases, else
              and by default return the path for the cache file which
@@ -158,7 +158,34 @@ def _cache_standard_names_to_dotfile(
     include_aliases=False,
     table_version=None,
 ):
-    """Create a pickle cache of the frozenset of fetched standard names."""
+    """Create a pickle cache of the frozenset of fetched standard names.
+
+    .. versionadded:: NEXTVERSION
+
+     :Parameters:
+
+         standard_names: `frozenset`
+             The set of all CF Conventions standard names in the
+             given version of the table, including aliases if
+             requested, to save to a new cache file.
+
+         include_aliases: `bool`, optional
+             Set to `True` if the file will cache standard names
+             inclusive of standard name aliases, else and by
+             default the cache file name is chosen to reflect
+             that it does not include aliases.
+
+         table_version: `str` or `None`, optional
+             The version of the standard names table of the XML
+             document, to register as metadata for the cache file.
+             If `None`, as default, then do not register a version.
+
+     :Returns:
+
+         `str`
+             The filesystem path to the newly-created cache file.
+
+    """
     cache_file = _get_cache_file_path(include_aliases=include_aliases)
 
     # Include some metadata with the frozen set of names, to allow us to detect if
@@ -182,7 +209,26 @@ def _cache_standard_names_to_dotfile(
 
 
 def _load_standard_names_from_dotfile(include_aliases=False):
-    """Load a pickled dotfile cache of standard names, or None if unavailable/stale."""
+    """Attempt to load and open a pickled dotfile cache of standard names.
+
+    .. versionadded:: NEXTVERSION
+
+     :Parameters:
+
+         include_aliases: `bool`, optional
+             If `True`, try to load and open the file which caches
+             standard names inclusive of standard name aliases, else
+             and by default load and open the path for the cache file
+             which does not include aliases.
+
+     :Returns:
+
+         `frozenset` or `None`
+             The set of all CF Conventions standard names taken from
+             the pickled dotfile cache or `None` if a valid cache
+             file could not be opened.
+
+    """
     cache_file = _get_cache_file_path(include_aliases=include_aliases)
 
     try:

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import pickle
 import xml.etree.ElementTree as ET
 from functools import lru_cache
 
@@ -23,6 +25,10 @@ _STD_NAME_CURRENT_XML_URL = (
     "cf-standard-names/current/src/cf-standard-name-table.xml"
 )
 DEFAULT_TIMEOUT = 5  # seconds
+
+# Cache config.
+CACHE_DIR = ".cf"
+CACHE_PICKLE_FILENAME = "standard_names.pickle"
 
 
 class StandardNameTableUnavailableError(Exception):
@@ -86,6 +92,27 @@ def _extract_names_from_xml(snames_xml, include_aliases):
     return frozenset(all_standard_names)
 
 
+def _get_cache_file_path():
+    """TODO."""
+    cache_dir = os.path.join(os.path.expanduser("~"), CACHE_DIR)
+    if not os.path.isdir(cache_dir):
+        os.makedirs(cache_dir)
+
+    return os.path.join(cache_dir, CACHE_PICKLE_FILENAME)
+
+
+def _dotfile_cache_fetched_standard_names(
+    standard_names, include_aliases=False
+):
+    """Create a pickle cache of the frozenset of fetched names."""
+    cache_file = _get_cache_file_path()
+
+    with open(cache_file, "wb") as f:
+        pickle.dump(standard_names, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    return cache_file
+
+
 @lru_cache
 def get_all_current_standard_names(include_aliases=False):
     """Get list of all CF Standard Names from the current table.
@@ -122,6 +149,16 @@ def get_all_current_standard_names(include_aliases=False):
         _STD_NAME_CURRENT_XML_URL,
     )  # pragma: no cover
 
+    # First attempt to get a cached version from a pickle of the frozenset
+    # of names that may have been fetched and stored at an earlier time
+    cache_file = _get_cache_file_path()
+    try:
+        with open(cache_file, "rb") as f:
+            return pickle.load(f)
+    except (IOError, EOFError, pickle.UnpicklingError):
+        # Cache doesn't exist or is corrupt
+        pass
+
     try:
         with request.urlopen(
             _STD_NAME_CURRENT_XML_URL,
@@ -133,17 +170,10 @@ def get_all_current_standard_names(include_aliases=False):
             f"Successfully retrieved list of {len(all_snames_xml)} "
             "standard names"
         )  # pragma: no cover
-
-        return _extract_names_from_xml(
-            all_snames_xml,
-            include_aliases=include_aliases,
-        )
-
     except (
         # urllib failures surface as OSError subclasses e.g. error.URLError
         OSError,
         TimeoutError,
-        ET.ParseError,  # TODO need care with this, could mask bugs in above
     ) as exc:
         logger.warning(
             "Unable to retrieve CF standard names so skipping validation "
@@ -152,3 +182,17 @@ def get_all_current_standard_names(include_aliases=False):
         # Note that lru_cache doesn't cache exceptions, so best return this here
         # but it can be caught later to prevent erroring for bypassing validation
         raise StandardNameTableUnavailableError from exc
+
+    # Be careful even with parsing since there's a small chance the XML could be bad
+    try:
+        names_set = _extract_names_from_xml(
+            all_snames_xml,
+            include_aliases=include_aliases,
+        )
+    except ET.ParseError as exc:
+        raise StandardNameTableUnavailableError(
+            "Downloaded CF standard name table is not valid XML."
+        ) from exc
+
+    _dotfile_cache_fetched_standard_names(names_set, include_aliases=False)
+    return names_set

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -25,7 +25,7 @@ _STD_NAME_CURRENT_XML_URL = (
     "cf-convention/cf-convention.github.io/refs/heads/main/Data/"
     "cf-standard-names/current/src/cf-standard-name-table.xml"
 )
-DEFAULT_TIMEOUT = 5  # seconds
+DEFAULT_TIMEOUT_SECONDS = 5
 
 # Cache config.
 CACHE_DIR = ".cf"
@@ -230,7 +230,7 @@ def get_all_current_standard_names(include_aliases=False):
     try:
         with request.urlopen(
             _STD_NAME_CURRENT_XML_URL,
-            timeout=DEFAULT_TIMEOUT,
+            timeout=DEFAULT_TIMEOUT_SECONDS,
         ) as response:
             all_snames_xml = response.read()
 

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -97,13 +97,46 @@ def _extract_names_from_xml(snames_xml, include_aliases):
 
 
 def _extract_table_version_from_xml(snames_xml):
-    """TODO."""
+    """Extract table version from a valid Standard Name Table XML document.
+
+    .. versionadded:: NEXTVERSION
+
+     :Parameters:
+
+         snames_xml: `bytes`
+             Bytes representing an XML file of any
+             valid Standard Name Table XML document, or mocked-up
+             equivalent form. 'version_number' is extracted.
+
+     :Returns:
+
+         `str`
+             The version of the standard names table of the XML document.
+
+    """
     root = ET.fromstring(snames_xml)
     return root.findtext("version_number")
 
 
 def _get_cache_file_path(include_aliases=False):
-    """TODO."""
+    """Return the filesystem path to the standard names pickle cache file.
+
+    .. versionadded:: NEXTVERSION
+
+     :Parameters:
+
+         include_aliases: `bool`
+             If `True`, return the path of the file which caches
+             standard names inclusive of standard name aliases, else
+             and by default return the path for the cache file which
+             does not include aliases.
+
+     :Returns:
+
+         `str`
+             The filesystem path to the cache file.
+
+    """
     cache_dir = os.path.join(
         os.path.expanduser("~"),
         CACHE_DIR,
@@ -125,7 +158,7 @@ def _cache_standard_names_to_dotfile(
     include_aliases=False,
     table_version=None,
 ):
-    """Create a pickle cache of the frozenset of fetched names."""
+    """Create a pickle cache of the frozenset of fetched standard names."""
     cache_file = _get_cache_file_path(include_aliases=include_aliases)
 
     # Include some metadata with the frozen set of names, to allow us to detect if

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -128,4 +128,4 @@ def get_all_current_standard_names(include_aliases=False):
             "Unable to retrieve CF standard names so skipping validation "
             f"against standard name table. Reason: {exc}",
         )
-        return {}
+        return frozenset()

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -25,6 +25,20 @@ _STD_NAME_CURRENT_XML_URL = (
 DEFAULT_TIMEOUT = 5  # seconds
 
 
+class StandardNameTableUnavailableError(Exception):
+    """Raise when the standard names table cannot be accessed."""
+
+    def __init__(self, reason=None):
+        """**Initialisation**"""
+        message = (
+            "Unable to retrieve the CF standard name table. Skipping "
+            "validation of any encoded (computed)_standard_names."
+        )
+        if reason is not None:
+            message += f" Reason: {reason}"
+        super().__init__(message)
+
+
 def _extract_names_from_xml(snames_xml, include_aliases):
     """Extract all names from a valid Standard Name Table XML document.
 
@@ -128,4 +142,6 @@ def get_all_current_standard_names(include_aliases=False):
             "Unable to retrieve CF standard names so skipping validation "
             f"against standard name table. Reason: {exc}",
         )
-        return frozenset()
+        # Note that lru_cache doesn't cache exceptions, so best return this here
+        # but it can be caught later to prevent erroring for bypassing validation
+        raise StandardNameTableUnavailableError from exc

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -1,10 +1,11 @@
 import logging
+import xml.etree.ElementTree as ET
 from functools import lru_cache
 
 # Prefer using built-in urllib to extract XML from cf-convention.github.io repo
 # over the 'github' module to use the GitHub API directly, because it avoids
 # the need for another dependency to the CF Data Tools.
-from urllib import request
+from urllib import error, request
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,7 @@ _STD_NAME_CURRENT_XML_URL = (
     "cf-convention/cf-convention.github.io/refs/heads/main/Data/"
     "cf-standard-names/current/src/cf-standard-name-table.xml"
 )
+DEFAULT_TIMEOUT = 10  # seconds
 
 
 def _extract_names_from_xml(snames_xml, include_aliases):
@@ -52,9 +54,6 @@ def _extract_names_from_xml(snames_xml, include_aliases):
              requested.
 
     """
-    # To parse the XML - much better than using manual regex parsing
-    import xml.etree.ElementTree as ET
-
     root = ET.fromstring(snames_xml)
     # Want all <entry id="..."> elements. Note the regex this corresponds
     # to, from SLB older code, is 're.compile(r"<entry id=\"(.+)\">")' but
@@ -99,13 +98,32 @@ def get_all_current_standard_names(include_aliases=False):
         "Retrieving XML for set of current standard names from: ",
         _STD_NAME_CURRENT_XML_URL,
     )  # pragma: no cover
-    with request.urlopen(_STD_NAME_CURRENT_XML_URL) as response:
-        all_snames_xml = response.read()
 
-    logger.debug(
-        f"Successfully retrieved list of {len(all_snames_xml)} standard names"
-    )  # pragma: no cover
+    try:
+        with request.urlopen(
+            _STD_NAME_CURRENT_XML_URL,
+            timeout=DEFAULT_TIMEOUT,
+        ) as response:
+            all_snames_xml = response.read()
 
-    return _extract_names_from_xml(
-        all_snames_xml, include_aliases=include_aliases
-    )
+        logger.debug(
+            f"Successfully retrieved list of {len(all_snames_xml)} "
+            "standard names"
+        )  # pragma: no cover
+
+        return _extract_names_from_xml(
+            all_snames_xml,
+            include_aliases=include_aliases,
+        )
+
+    except (
+        error.URLError,
+        error.HTTPError,
+        TimeoutError,
+        ET.ParseError,
+    ) as exc:
+        logger.warning(
+            "Unable to retrieve CF standard names so skipping validation "
+            f"against standard name table. Reason: {exc}",
+        )
+        return []

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -101,9 +101,7 @@ def _get_cache_file_path():
     return os.path.join(cache_dir, CACHE_PICKLE_FILENAME)
 
 
-def _dotfile_cache_fetched_standard_names(
-    standard_names, include_aliases=False
-):
+def _cache_to_dotfile_standard_names(standard_names, include_aliases=False):
     """Create a pickle cache of the frozenset of fetched names."""
     cache_file = _get_cache_file_path()
 
@@ -111,6 +109,18 @@ def _dotfile_cache_fetched_standard_names(
         pickle.dump(standard_names, f, protocol=pickle.HIGHEST_PROTOCOL)
 
     return cache_file
+
+
+def _load_from_dotfile_with_standard_names(include_aliases=False):
+    """Load a pickle cache of the frozenset of fetched names."""
+    cache_file = _get_cache_file_path()
+    print("CACHE IS AT:", cache_file)
+    try:
+        with open(cache_file, "rb") as f:
+            return pickle.load(f)
+    except (IOError, EOFError, pickle.UnpicklingError):
+        # Cache doesn't exist or is corrupt
+        return False
 
 
 @lru_cache
@@ -151,13 +161,11 @@ def get_all_current_standard_names(include_aliases=False):
 
     # First attempt to get a cached version from a pickle of the frozenset
     # of names that may have been fetched and stored at an earlier time
-    cache_file = _get_cache_file_path()
-    try:
-        with open(cache_file, "rb") as f:
-            return pickle.load(f)
-    except (IOError, EOFError, pickle.UnpicklingError):
-        # Cache doesn't exist or is corrupt
-        pass
+    pickled_names = _load_from_dotfile_with_standard_names(
+        include_aliases=False
+    )
+    if pickled_names:
+        return pickled_names
 
     try:
         with request.urlopen(
@@ -191,8 +199,8 @@ def get_all_current_standard_names(include_aliases=False):
         )
     except ET.ParseError as exc:
         raise StandardNameTableUnavailableError(
-            "Downloaded CF standard name table is not valid XML."
+            "Downloaded CF standard name table is not valid XML and cannot be parsed."
         ) from exc
 
-    _dotfile_cache_fetched_standard_names(names_set, include_aliases=False)
+    _cache_to_dotfile_standard_names(names_set, include_aliases=False)
     return names_set

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 # Prefer using built-in urllib to extract XML from cf-convention.github.io repo
 # over the 'github' module to use the GitHub API directly, because it avoids
 # the need for another dependency to the CF Data Tools.
-from urllib import error, request
+from urllib import request
 
 logger = logging.getLogger(__name__)
 
@@ -119,10 +119,10 @@ def get_all_current_standard_names(include_aliases=False):
         )
 
     except (
-        error.URLError,
-        error.HTTPError,
+        # urllib failures surface as OSError subclasses e.g. error.URLError
+        OSError,
         TimeoutError,
-        ET.ParseError,
+        ET.ParseError,  # TODO need care with this, could mask bugs in above
     ) as exc:
         logger.warning(
             "Unable to retrieve CF standard names so skipping validation "

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -48,8 +48,8 @@ def _extract_names_from_xml(snames_xml, include_aliases):
 
      :Returns:
 
-         `list`
-             A list of all CF Conventions standard names in the
+         `frozenset`
+             A set of all CF Conventions standard names in the
              given version of the table, including aliases if
              requested.
 
@@ -58,15 +58,17 @@ def _extract_names_from_xml(snames_xml, include_aliases):
     # Want all <entry id="..."> elements. Note the regex this corresponds
     # to, from SLB older code, is 're.compile(r"<entry id=\"(.+)\">")' but
     # using the ElementTree is a much more robust means to extract
-    all_standard_names = [
+    all_standard_names = {
         entry.attrib["id"] for entry in root.findall(".//entry")
-    ]
+    }
     if include_aliases:
-        all_standard_names += [
+        all_standard_names.update(
             entry.attrib["id"] for entry in root.findall(".//alias")
-        ]
+        )
 
-    return all_standard_names
+    # Set is more performant than a list for membership testing, so convert.
+    # Use a frozen set form so users can't edit it (by mistake or otherwise!).
+    return frozenset(all_standard_names)
 
 
 @lru_cache
@@ -88,8 +90,8 @@ def get_all_current_standard_names(include_aliases=False):
 
      :Returns:
 
-         `list`
-             A list of all CF Conventions standard names in the
+         `frozenset`
+             A set of all CF Conventions standard names in the
              current version of the table, including aliases if
              requested.
 
@@ -126,4 +128,4 @@ def get_all_current_standard_names(include_aliases=False):
             "Unable to retrieve CF standard names so skipping validation "
             f"against standard name table. Reason: {exc}",
         )
-        return []
+        return {}

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -28,7 +28,8 @@ DEFAULT_TIMEOUT = 5  # seconds
 
 # Cache config.
 CACHE_DIR = ".cf"
-CACHE_PICKLE_FILENAME = "standard_names.pickle"
+CACHE_PICKLE_FILENAME_NOALIASES = "standard_names.pickle"
+CACHE_PICKLE_FILENAME_WITHALIASES = "standard_names_with_aliases.pickle"
 
 
 class StandardNameTableUnavailableError(Exception):
@@ -92,35 +93,53 @@ def _extract_names_from_xml(snames_xml, include_aliases):
     return frozenset(all_standard_names)
 
 
-def _get_cache_file_path():
+def _get_cache_file_path(include_aliases=False):
     """TODO."""
-    cache_dir = os.path.join(os.path.expanduser("~"), CACHE_DIR)
+    cache_dir = os.path.join(
+        os.path.expanduser("~"),
+        CACHE_DIR,
+    )
+
     if not os.path.isdir(cache_dir):
         os.makedirs(cache_dir)
 
-    return os.path.join(cache_dir, CACHE_PICKLE_FILENAME)
+    if include_aliases:
+        filename = CACHE_PICKLE_FILENAME_WITHALIASES
+    else:
+        filename = CACHE_PICKLE_FILENAME_NOALIASES
+
+    return os.path.join(cache_dir, filename)
 
 
 def _cache_standard_names_to_dotfile(standard_names, include_aliases=False):
     """Create a pickle cache of the frozenset of fetched names."""
-    cache_file = _get_cache_file_path()
+    cache_file = _get_cache_file_path(include_aliases=include_aliases)
 
     with open(cache_file, "wb") as f:
         pickle.dump(standard_names, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    logger.info(
+        f"Cached set of fetched standard names to dotfile at {cache_file}"
+    )  # pragma: no cover
 
     return cache_file
 
 
 def _load_standard_names_from_dotfile(include_aliases=False):
     """Load a pickle cache of the frozenset of fetched names, or None on failure."""
-    cache_file = _get_cache_file_path()
-    print("CACHE IS AT:", cache_file)
+    cache_file = _get_cache_file_path(include_aliases=include_aliases)
+
     try:
         with open(cache_file, "rb") as f:
-            return pickle.load(f)
+            names = pickle.load(f)
     except (IOError, EOFError, pickle.UnpicklingError):
         # Cache doesn't exist or is corrupt
         return None
+
+    logger.info(
+        f"Loaded set of fetched standard names from dotfile at {cache_file}"
+    )  # pragma: no cover
+    return names
 
 
 @lru_cache
@@ -161,7 +180,9 @@ def get_all_current_standard_names(include_aliases=False):
 
     # First attempt to get a cached version from a pickle of the frozenset
     # of names that may have been fetched and stored at an earlier time
-    pickled_names = _load_standard_names_from_dotfile(include_aliases=False)
+    pickled_names = _load_standard_names_from_dotfile(
+        include_aliases=include_aliases
+    )
     if pickled_names:
         return pickled_names
 

--- a/cfdm/conformance/standardnames.py
+++ b/cfdm/conformance/standardnames.py
@@ -22,7 +22,7 @@ _STD_NAME_CURRENT_XML_URL = (
     "cf-convention/cf-convention.github.io/refs/heads/main/Data/"
     "cf-standard-names/current/src/cf-standard-name-table.xml"
 )
-DEFAULT_TIMEOUT = 10  # seconds
+DEFAULT_TIMEOUT = 5  # seconds
 
 
 def _extract_names_from_xml(snames_xml, include_aliases):

--- a/cfdm/read_write/netcdf/checker.py
+++ b/cfdm/read_write/netcdf/checker.py
@@ -84,12 +84,6 @@ class NetCDFCheckerMixin(Report):
         g = self.read_vars
 
         bounds_ncvar_attrs = g["variable_attributes"][bounds_ncvar]
-        self._check_standard_names(
-            parent_ncvar,
-            bounds_ncvar,
-            bounds_ncvar_attrs,
-        )
-
         if bounds_ncvar not in g["internal_variables"]:
             bounds_ncvar, message = self._missing_variable(
                 bounds_ncvar, variable_type
@@ -102,6 +96,12 @@ class NetCDFCheckerMixin(Report):
                 direct_parent_ncvar=coord_ncvar,
             )
             return False
+
+        self._check_standard_names(
+            parent_ncvar,
+            bounds_ncvar,
+            bounds_ncvar_attrs,
+        )
 
         ok = True
 
@@ -160,11 +160,6 @@ class NetCDFCheckerMixin(Report):
         geometry_ncvar = g["variable_geometry"].get(field_ncvar)
 
         geometry_ncvar_attrs = g["variable_attributes"][geometry_ncvar]
-        self._check_standard_names(
-            node_ncvar,
-            geometry_ncvar,
-            geometry_ncvar_attrs,
-        )
 
         attribute = {
             field_ncvar
@@ -184,6 +179,12 @@ class NetCDFCheckerMixin(Report):
                 direct_parent_ncvar=field_ncvar,
             )
             return False
+
+        self._check_standard_names(
+            node_ncvar,
+            geometry_ncvar,
+            geometry_ncvar_attrs,
+        )
 
         ok = True
 
@@ -368,11 +369,6 @@ class NetCDFCheckerMixin(Report):
 
         for ncvar in parsed_string:
             ncvar_attrs = g["variable_attributes"][ncvar]
-            self._check_standard_names(
-                parent_ncvar,
-                ncvar,
-                ncvar_attrs,
-            )
 
             # Check that the geometry variable exists in the file
             if ncvar not in g["variables"]:
@@ -387,6 +383,12 @@ class NetCDFCheckerMixin(Report):
                     conformance="?",
                 )
                 return False
+
+            self._check_standard_names(
+                parent_ncvar,
+                ncvar,
+                ncvar_attrs,
+            )
 
         return True
 
@@ -443,16 +445,6 @@ class NetCDFCheckerMixin(Report):
         ok = True
         for ncvar in parsed_string:
             ncvar_attrs = g["variable_attributes"][ncvar]
-            self._check_standard_names(
-                field_ncvar,
-                ncvar,
-                ncvar_attrs,
-            )
-            self._include_component_report(
-                field_ncvar,
-                ncvar,
-                "ancillary_variables",
-            )
 
             # Check that the variable exists in the file
             if ncvar not in g["internal_variables"]:
@@ -464,6 +456,17 @@ class NetCDFCheckerMixin(Report):
                 )
 
                 return False
+
+            self._check_standard_names(
+                field_ncvar,
+                ncvar,
+                ncvar_attrs,
+            )
+            self._include_component_report(
+                field_ncvar,
+                ncvar,
+                "ancillary_variables",
+            )
 
             if not self._dimensions_are_subset(
                 ncvar, self._ncdimensions(ncvar), parent_dimensions
@@ -509,17 +512,6 @@ class NetCDFCheckerMixin(Report):
         g = self.read_vars
 
         coord_ncvar_attrs = g["variable_attributes"][coord_ncvar]
-        self._check_standard_names(
-            parent_ncvar,
-            coord_ncvar,
-            coord_ncvar_attrs,
-        )
-        self._include_component_report(
-            parent_ncvar,
-            coord_ncvar,
-            "coordinates",
-        )
-
         if coord_ncvar not in g["internal_variables"]:
             coord_ncvar, message = self._missing_variable(
                 coord_ncvar, "Auxiliary/scalar coordinate variable"
@@ -539,6 +531,17 @@ class NetCDFCheckerMixin(Report):
                 conformance="5.requirement.5",
             )
             return False
+
+        self._check_standard_names(
+            parent_ncvar,
+            coord_ncvar,
+            coord_ncvar_attrs,
+        )
+        self._include_component_report(
+            parent_ncvar,
+            coord_ncvar,
+            "coordinates",
+        )
 
         # Check that the variable's dimensions span a subset of the
         # parent variable's dimensions (allowing for char variables
@@ -588,11 +591,6 @@ class NetCDFCheckerMixin(Report):
         g = self.read_vars
 
         tie_point_ncvar_attrs = g["variable_attributes"][tie_point_ncvar]
-        self._check_standard_names(
-            parent_ncvar,
-            tie_point_ncvar,
-            tie_point_ncvar_attrs,
-        )
 
         if tie_point_ncvar not in g["internal_variables"]:
             ncvar, message = self._missing_variable(
@@ -606,6 +604,12 @@ class NetCDFCheckerMixin(Report):
                 conformance="8.3.requirement.1",
             )
             return False
+
+        self._check_standard_names(
+            parent_ncvar,
+            tie_point_ncvar,
+            tie_point_ncvar_attrs,
+        )
 
         # Check that the variable's dimensions span a subset of the
         # parent variable's dimensions (allowing for char variables
@@ -769,11 +773,6 @@ class NetCDFCheckerMixin(Report):
         g = self.read_vars
 
         geometry_ncvar_attrs = g["variable_attributes"][geometry_ncvar]
-        self._check_standard_names(
-            field_ncvar,
-            geometry_ncvar,
-            geometry_ncvar_attrs,
-        )
 
         incorrectly_formatted = (
             "node_coordinates attribute",
@@ -800,6 +799,12 @@ class NetCDFCheckerMixin(Report):
             )
             return False
 
+        self._check_standard_names(
+            field_ncvar,
+            geometry_ncvar,
+            geometry_ncvar_attrs,
+        )
+
         ok = True
 
         for ncvar in parsed_node_coordinates:
@@ -820,6 +825,12 @@ class NetCDFCheckerMixin(Report):
                     field_ncvar, ncvar, message=message, attribute=attribute
                 )
                 ok = False
+
+            self._check_standard_names(
+                field_ncvar,
+                ncvar,
+                ncvar_attrs,
+            )
 
         return ok
 
@@ -852,11 +863,6 @@ class NetCDFCheckerMixin(Report):
 
         for ncvar in parsed_node_count:
             ncvar_attrs = g["variable_attributes"][ncvar]
-            self._check_standard_names(
-                field_ncvar,
-                ncvar,
-                ncvar_attrs,
-            )
 
             # Check that the node count variable exists in the file
             if ncvar not in g["internal_variables"]:
@@ -867,6 +873,12 @@ class NetCDFCheckerMixin(Report):
                     field_ncvar, ncvar, message=message, attribute=attribute
                 )
                 ok = False
+
+            self._check_standard_names(
+                field_ncvar,
+                ncvar,
+                ncvar_attrs,
+            )
 
         return ok
 
@@ -903,11 +915,6 @@ class NetCDFCheckerMixin(Report):
 
         for ncvar in parsed_part_node_count:
             ncvar_attrs = g["variable_attributes"][ncvar]
-            self._check_standard_names(
-                field_ncvar,
-                ncvar,
-                ncvar_attrs,
-            )
 
             # Check that the variable exists in the file
             if ncvar not in g["internal_variables"]:
@@ -918,6 +925,12 @@ class NetCDFCheckerMixin(Report):
                     field_ncvar, ncvar, message=message, attribute=attribute
                 )
                 ok = False
+
+            self._check_standard_names(
+                field_ncvar,
+                ncvar,
+                ncvar_attrs,
+            )
 
         return ok
 
@@ -965,11 +978,6 @@ class NetCDFCheckerMixin(Report):
 
         for ncvar in parsed_interior_ring:
             ncvar_attrs = g["variable_attributes"][ncvar]
-            self._check_standard_names(
-                field_ncvar,
-                ncvar,
-                ncvar_attrs,
-            )
 
             # Check that the variable exists in the file
             if ncvar not in g["internal_variables"]:
@@ -980,6 +988,12 @@ class NetCDFCheckerMixin(Report):
                     field_ncvar, ncvar, message=message, attribute=attribute
                 )
                 ok = False
+
+            self._check_standard_names(
+                field_ncvar,
+                ncvar,
+                ncvar_attrs,
+            )
 
         return ok
 
@@ -1085,11 +1099,6 @@ class NetCDFCheckerMixin(Report):
 
         for interp_ncvar, coords in parsed_coordinate_interpolation.items():
             interp_ncvar_attrs = g["variable_attributes"][interp_ncvar]
-            self._check_standard_names(
-                parent_ncvar,
-                interp_ncvar,
-                interp_ncvar_attrs,
-            )
 
             # Check that the interpolation variable exists in the file
             if interp_ncvar not in g["internal_variables"]:
@@ -1100,6 +1109,12 @@ class NetCDFCheckerMixin(Report):
                     parent_ncvar, ncvar, message=message, attribute=attribute
                 )
                 ok = False
+
+            self._check_standard_names(
+                parent_ncvar,
+                interp_ncvar,
+                interp_ncvar_attrs,
+            )
 
             attrs = g["variable_attributes"][interp_ncvar]
             if "tie_point_mapping" not in attrs:
@@ -1120,11 +1135,6 @@ class NetCDFCheckerMixin(Report):
                 tie_point_interp_ncvar_attrs = g["variable_attributes"][
                     tie_point_ncvar
                 ]
-                self._check_standard_names(
-                    parent_ncvar,
-                    tie_point_ncvar,
-                    tie_point_interp_ncvar_attrs,
-                )
 
                 if tie_point_ncvar not in g["internal_variables"]:
                     ncvar, message = self._missing_variable(
@@ -1137,6 +1147,12 @@ class NetCDFCheckerMixin(Report):
                         attribute=attribute,
                     )
                     ok = False
+
+                self._check_standard_names(
+                    parent_ncvar,
+                    tie_point_ncvar,
+                    tie_point_interp_ncvar_attrs,
+                )
 
         # TODO check tie point variable dimensions
 
@@ -1165,11 +1181,6 @@ class NetCDFCheckerMixin(Report):
         g = self.read_vars
 
         ncvar_attrs = g["variable_attributes"][ncvar]
-        self._check_standard_names(
-            parent_ncvar,
-            ncvar,
-            ncvar_attrs,
-        )
 
         # Check that the quantization variable exists in the file
         ok = True
@@ -1184,6 +1195,12 @@ class NetCDFCheckerMixin(Report):
                 attribute=attribute,
             )
             ok = False
+
+        self._check_standard_names(
+            parent_ncvar,
+            ncvar,
+            ncvar_attrs,
+        )
 
         attributes = g["variable_attributes"][ncvar]
 
@@ -1630,12 +1647,6 @@ class NetCDFCheckerMixin(Report):
 
         attributes = g["variable_attributes"][mesh_ncvar]
 
-        self._check_standard_names(
-            mesh_ncvar,
-            mesh_ncvar,
-            attributes,
-        )
-
         ok = True
 
         if mesh_ncvar not in g["internal_variables"]:
@@ -1650,6 +1661,12 @@ class NetCDFCheckerMixin(Report):
             )
             ok = False
             return ok
+
+        self._check_standard_names(
+            mesh_ncvar,
+            mesh_ncvar,
+            attributes,
+        )
 
         node_coordinates = attributes.get("node_coordinates")
         if node_coordinates is None:
@@ -1769,11 +1786,6 @@ class NetCDFCheckerMixin(Report):
         elif topology_dimension == 1:
             ncvar = attributes.get("edge_node_connectivity")
             ncvar_attrs = g["variable_attributes"][ncvar]
-            self._check_standard_names(
-                mesh_ncvar,
-                ncvar,
-                ncvar_attrs,
-            )
 
             if ncvar is None:
                 self._add_message(
@@ -1794,14 +1806,15 @@ class NetCDFCheckerMixin(Report):
                     attribute={f"{mesh_ncvar}:edge_node_connectivity": ncvar},
                 )
                 ok = False
-        elif topology_dimension == 3:
-            ncvar = attributes.get("volume_node_connectivity")
-            ncvar_attrs = g["variable_attributes"][ncvar]
+
             self._check_standard_names(
                 mesh_ncvar,
                 ncvar,
                 ncvar_attrs,
             )
+        elif topology_dimension == 3:
+            ncvar = attributes.get("volume_node_connectivity")
+            ncvar_attrs = g["variable_attributes"][ncvar]
 
             if ncvar is None:
                 self._add_message(
@@ -1827,6 +1840,12 @@ class NetCDFCheckerMixin(Report):
                     },
                 )
                 ok = False
+
+            self._check_standard_names(
+                mesh_ncvar,
+                ncvar,
+                ncvar_attrs,
+            )
 
             ncvar = attributes.get("volume_shape_type")
             if ncvar is None:
@@ -1909,11 +1928,6 @@ class NetCDFCheckerMixin(Report):
 
         mesh_ncvar = location_index_set_attributes.get("mesh")
         mesh_ncvar_attrs = g["variable_attributes"][mesh_ncvar]
-        self._check_standard_names(
-            location_index_set_ncvar,
-            mesh_ncvar,
-            mesh_ncvar_attrs,
-        )
 
         if mesh_ncvar is None:
             self._add_message(
@@ -1942,6 +1956,12 @@ class NetCDFCheckerMixin(Report):
                 attribute={f"{location_index_set_ncvar}:mesh": mesh_ncvar},
             )
             ok = False
+
+        self._check_standard_names(
+            location_index_set_ncvar,
+            mesh_ncvar,
+            mesh_ncvar_attrs,
+        )
 
         return ok
 
@@ -2004,11 +2024,6 @@ class NetCDFCheckerMixin(Report):
         location_index_set_attributes = g["variable_attributes"][
             location_index_set_ncvar
         ]
-        self._check_standard_names(
-            parent_ncvar,
-            location_index_set_ncvar,
-            location_index_set_attributes,
-        )
 
         location = location_index_set_attributes.get("location")
         if location is None:
@@ -2055,6 +2070,12 @@ class NetCDFCheckerMixin(Report):
                 attribute={f"{location_index_set_ncvar}:mesh": mesh_ncvar},
             )
             ok = False
+
+        self._check_standard_names(
+            parent_ncvar,
+            location_index_set_ncvar,
+            location_index_set_attributes,
+        )
 
         parent_ncdims = self._ncdimensions(parent_ncvar)
         lis_ncdims = self._ncdimensions(location_index_set_ncvar)
@@ -2203,12 +2224,6 @@ class NetCDFCheckerMixin(Report):
         g = self.read_vars
 
         ncvar_attrs = g["variable_attributes"][connectivity_ncvar]
-        self._check_standard_names(
-            parent_ncvar,
-            connectivity_ncvar,
-            ncvar_attrs,
-            direct_parent_ncvar=mesh_ncvar,
-        )
 
         ok = True
         if connectivity_ncvar is None:
@@ -2236,6 +2251,13 @@ class NetCDFCheckerMixin(Report):
             )
             ok = False
             return ok
+
+        self._check_standard_names(
+            parent_ncvar,
+            connectivity_ncvar,
+            ncvar_attrs,
+            direct_parent_ncvar=mesh_ncvar,
+        )
 
         parent_ncdims = self._ncdimensions(parent_ncvar)
         connectivity_ncdims = self._ncdimensions(connectivity_ncvar)[0]

--- a/cfdm/read_write/netcdf/checker.py
+++ b/cfdm/read_write/netcdf/checker.py
@@ -1659,8 +1659,7 @@ class NetCDFCheckerMixin(Report):
                 message=message,
                 attribute={f"{mesh_ncvar}:mesh": mesh_ncvar},
             )
-            ok = False
-            return ok
+            return False
 
         self._check_standard_names(
             mesh_ncvar,
@@ -2233,8 +2232,7 @@ class NetCDFCheckerMixin(Report):
                 message=(f"{connectivity_attr} attribute", "is missing"),
                 direct_parent_ncvar=mesh_ncvar,
             )
-            ok = False
-            return ok
+            return False
 
         if connectivity_ncvar not in g["internal_variables"]:
             connectivity_ncvar, message = self._missing_variable(
@@ -2249,8 +2247,7 @@ class NetCDFCheckerMixin(Report):
                 },
                 direct_parent_ncvar=mesh_ncvar,
             )
-            ok = False
-            return ok
+            return False
 
         self._check_standard_names(
             parent_ncvar,

--- a/cfdm/test/test_compliance_checking.py
+++ b/cfdm/test/test_compliance_checking.py
@@ -317,8 +317,11 @@ class ComplianceCheckingTest(unittest.TestCase):
         self.assertIn("moles_of_cfc113_in_atmosphere", aliases_inc_output)
 
     @patch("cfdm.conformance.standardnames.request.urlopen")
+    @patch("cfdm.conformance.standardnames._load_standard_names_from_dotfile")
     def test_get_all_current_standard_names_network_failure(
-        self, mock_urlopen
+        self,
+        mock_load_dotfile,
+        mock_urlopen,
     ):
         """Test `get_all_current_standard_names` when resource unavailable."""
         exceptions = [
@@ -334,13 +337,15 @@ class ComplianceCheckingTest(unittest.TestCase):
             TimeoutError("Request timed out"),
         ]
 
+        # No cached copy available
+        mock_load_dotfile.return_value = None
+
         for exc in exceptions:
             with self.subTest(exception=type(exc).__name__):
-                # Avoid previous tests populating the cache
+                # Avoid previous successful calls being returned from lru_cache
                 get_all_current_standard_names.cache_clear()
 
-                # Mock to represent cases whereby the standard names table is
-                # not accessible that we catch in the function
+                # Remote resource unavailable
                 mock_urlopen.side_effect = exc
 
                 with self.assertRaises(StandardNameTableUnavailableError):

--- a/cfdm/test/test_compliance_checking.py
+++ b/cfdm/test/test_compliance_checking.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from unittest.mock import patch  # not included as standard with module
 from urllib import request
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 from netCDF4 import Dataset
 
@@ -320,15 +320,32 @@ class ComplianceCheckingTest(unittest.TestCase):
         self, mock_urlopen
     ):
         """Test `get_all_current_standard_names` when resource unavailable."""
-        # Mock to represent the network going down so that the standard names
-        # table is not accessible
-        mock_urlopen.side_effect = URLError("Connection failed")
+        exceptions = [
+            URLError("Connection failed"),
+            HTTPError(
+                _STD_NAME_CURRENT_XML_URL,
+                503,
+                "Service unavailable",
+                hdrs=None,
+                fp=None,
+            ),
+            OSError("Underlying network error"),
+            TimeoutError("Request timed out"),
+        ]
 
-        # Avoid previous tests populating the cache
-        get_all_current_standard_names.cache_clear()
+        for exc in exceptions:
+            with self.subTest(exception=type(exc).__name__):
+                # Avoid previous tests populating the cache
+                get_all_current_standard_names.cache_clear()
 
-        output = get_all_current_standard_names()
-        self.assertEqual(output, frozenset())
+                # Mock to represent cases whereby the standard names table is
+                # not accessible that we catch in the function
+                mock_urlopen.side_effect = exc
+
+                output = get_all_current_standard_names()
+
+                self.assertIsInstance(output, frozenset)
+                self.assertEqual(output, frozenset())
 
     def test_standard_names_validation_compliant_field(self):
         """Test compliance checking on a compliant non-UGRID field."""

--- a/cfdm/test/test_compliance_checking.py
+++ b/cfdm/test/test_compliance_checking.py
@@ -201,7 +201,7 @@ class ComplianceCheckingTest(unittest.TestCase):
         two_name_output = cfdm.conformance._extract_names_from_xml(
             two_name_table_start + table_end, include_aliases=False
         )
-        self.assertIsInstance(two_name_output, list)
+        self.assertIsInstance(two_name_output, frozenset)
         self.assertEqual(len(two_name_output), 2)
         self.assertIn(
             "acoustic_area_backscattering_strength_in_sea_water",
@@ -222,7 +222,7 @@ class ComplianceCheckingTest(unittest.TestCase):
             two_name_table_start + include_two_aliases + table_end,
             include_aliases=True,
         )
-        self.assertIsInstance(aliases_inc_output, list)
+        self.assertIsInstance(aliases_inc_output, frozenset)
         self.assertEqual(len(aliases_inc_output), 4)
         # Check all non-aliases are there, as per above output
         self.assertTrue(set(two_name_output).issubset(aliases_inc_output))
@@ -261,7 +261,7 @@ class ComplianceCheckingTest(unittest.TestCase):
         # name validation with a warning, in these cases.
 
         output = cfdm.conformance.get_all_current_standard_names()
-        self.assertIsInstance(output, list)
+        self.assertIsInstance(output, frozenset)
 
         # The function gets the current table so we can't know exactly how
         # many names there will be there going forward, but given there are
@@ -291,7 +291,7 @@ class ComplianceCheckingTest(unittest.TestCase):
         aliases_inc_output = cfdm.conformance.get_all_current_standard_names(
             include_aliases=True
         )
-        self.assertIsInstance(aliases_inc_output, list)
+        self.assertIsInstance(aliases_inc_output, frozenset)
 
         # As with above length check, can't be sure of eact amount as it
         # changes but we can safely put a lower limit on it. At time of

--- a/cfdm/test/test_compliance_checking.py
+++ b/cfdm/test/test_compliance_checking.py
@@ -4,7 +4,9 @@ import faulthandler
 import os
 import tempfile
 import unittest
+from unittest.mock import patch  # not included as standard with module
 from urllib import request
+from urllib.error import URLError
 
 from netCDF4 import Dataset
 
@@ -312,6 +314,21 @@ class ComplianceCheckingTest(unittest.TestCase):
 
         # This time the alias should be included
         self.assertIn("moles_of_cfc113_in_atmosphere", aliases_inc_output)
+
+    @patch("cfdm.conformance.standardnames.request.urlopen")
+    def test_get_all_current_standard_names_network_failure(
+        self, mock_urlopen
+    ):
+        """Test `get_all_current_standard_names` when resource unavailable."""
+        # Mock to represent the network going down so that the standard names
+        # table is not accessible
+        mock_urlopen.side_effect = URLError("Connection failed")
+
+        # Avoid previous tests populating the cache
+        get_all_current_standard_names.cache_clear()
+
+        output = get_all_current_standard_names()
+        self.assertEqual(output, frozenset())
 
     def test_standard_names_validation_compliant_field(self):
         """Test compliance checking on a compliant non-UGRID field."""

--- a/cfdm/test/test_compliance_checking.py
+++ b/cfdm/test/test_compliance_checking.py
@@ -12,6 +12,13 @@ faulthandler.enable()  # to debug seg faults and timeouts
 
 import cfdm
 
+# Not exposed in public API so these need importing directly from sub-module
+from cfdm.conformance.standardnames import (
+    _STD_NAME_CURRENT_XML_URL,
+    _extract_names_from_xml,
+    get_all_current_standard_names,
+)
+
 n_tmpfiles = 3
 tmpfiles = [
     tempfile.mkstemp("_test_compliance_check.nc", dir=os.getcwd())[1]
@@ -198,7 +205,7 @@ class ComplianceCheckingTest(unittest.TestCase):
         """
         table_end = "</standard_name_table>"
 
-        two_name_output = cfdm.conformance._extract_names_from_xml(
+        two_name_output = _extract_names_from_xml(
             two_name_table_start + table_end, include_aliases=False
         )
         self.assertIsInstance(two_name_output, frozenset)
@@ -212,13 +219,13 @@ class ComplianceCheckingTest(unittest.TestCase):
         # No aliases in this table therefore expect same output as before
         # when setting 'include_aliases=True'
         self.assertEqual(
-            cfdm.conformance._extract_names_from_xml(
+            _extract_names_from_xml(
                 two_name_table_start + table_end, include_aliases=True
             ),
             two_name_output,
         )
 
-        aliases_inc_output = cfdm.conformance._extract_names_from_xml(
+        aliases_inc_output = _extract_names_from_xml(
             two_name_table_start + include_two_aliases + table_end,
             include_aliases=True,
         )
@@ -237,7 +244,7 @@ class ComplianceCheckingTest(unittest.TestCase):
         # When setting 'include_aliases=True' should ignore the two aliases
         # in table so expect same as two_name_output
         self.assertEqual(
-            cfdm.conformance._extract_names_from_xml(
+            _extract_names_from_xml(
                 two_name_table_start + include_two_aliases + table_end,
                 include_aliases=False,
             ),
@@ -248,7 +255,7 @@ class ComplianceCheckingTest(unittest.TestCase):
         """Test `conformance.get_all_current_standard_names` function."""
         # First check the URL used is actually available in case of issues
         # arising in case GitHub endpoints go down
-        sn_xml_url = cfdm.conformance._STD_NAME_CURRENT_XML_URL
+        sn_xml_url = _STD_NAME_CURRENT_XML_URL
         with request.urlopen(sn_xml_url) as response:
             self.assertEqual(
                 response.status,
@@ -260,7 +267,7 @@ class ComplianceCheckingTest(unittest.TestCase):
         # case that the URL isn't accessible? Ideally we can skip standard
         # name validation with a warning, in these cases.
 
-        output = cfdm.conformance.get_all_current_standard_names()
+        output = get_all_current_standard_names()
         self.assertIsInstance(output, frozenset)
 
         # The function gets the current table so we can't know exactly how
@@ -288,7 +295,7 @@ class ComplianceCheckingTest(unittest.TestCase):
         # of the above should not be in the list
         self.assertNotIn("moles_of_cfc113_in_atmosphere", output)
 
-        aliases_inc_output = cfdm.conformance.get_all_current_standard_names(
+        aliases_inc_output = get_all_current_standard_names(
             include_aliases=True
         )
         self.assertIsInstance(aliases_inc_output, frozenset)

--- a/cfdm/test/test_compliance_checking.py
+++ b/cfdm/test/test_compliance_checking.py
@@ -17,6 +17,7 @@ import cfdm
 # Not exposed in public API so these need importing directly from sub-module
 from cfdm.conformance.standardnames import (
     _STD_NAME_CURRENT_XML_URL,
+    StandardNameTableUnavailableError,
     _extract_names_from_xml,
     get_all_current_standard_names,
 )
@@ -342,10 +343,8 @@ class ComplianceCheckingTest(unittest.TestCase):
                 # not accessible that we catch in the function
                 mock_urlopen.side_effect = exc
 
-                output = get_all_current_standard_names()
-
-                self.assertIsInstance(output, frozenset)
-                self.assertEqual(output, frozenset())
+                with self.assertRaises(StandardNameTableUnavailableError):
+                    get_all_current_standard_names()
 
     def test_standard_names_validation_compliant_field(self):
         """Test compliance checking on a compliant non-UGRID field."""


### PR DESCRIPTION
...and generally improve and safeguard from network issues the handling of the fetching and storage of the names, e.g. store them as a frozenset rather than a list, which is more performant for membership testing and can't be edited by the user (whether by mistake, or otherwise!).

Specifically, this PR adds as a follow-on from #373:

* safe bypassing of standard names checks when the online XML can't be accessed (more likely but rare) or is not valid (rarer but possible);
* caching to a (pair, possibly of) local dotfiles under `~/.cf/` which store the names as a pickled frozen set and load them when required, including some basic cache metadata that will allow us to detect if a dotfile cache is old;
* timeouts on URL open attempts to prevent too much waiting on a resource (could be made configurable but for now I've set it as 5 seconds which seems sensible and proportionate given the size of the names XML).

And finally bundled here, since it is related to similar logic, is to move the checks to validate standard names after the checks that variables exists in all cases where the latter checks exist (that's the only sensible order there), all in [dfe1b0f](https://github.com/NCAS-CMS/cfdm/pull/411/commits/dfe1b0ff21970594db679b591a7f2fec3a047b90).