### PR TITLE
Set sensible dataset chunksizes by default for 1-d data

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,8 +1,10 @@
-Version ???
------------
+Version NEXTVERSION
+----------------
 
 **2026-??-??**
 
+* Set sensible dataset chunksizes by default for 1-d data
+  (https://github.com/NCAS-CMS/cfdm/issues/414)
 * Introduce use of cache files stored as `~/.cf/standard_names*.pickle`
   to improve performance of CF compliance checking
   (https://github.com/NCAS-CMS/cfdm/pull/411)

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -3045,7 +3045,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
                 .. versionadded:: (cfdm) 1.12.0.0
 
             bounds: `bool`
-                Whether or not the data represent bounds.
+                Whether or not the data represent cell bounds.
 
                 .. versionadded:: (cfdm) NEXTVERSION
 
@@ -6498,7 +6498,9 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
                 The dataset dimensions of the data.
 
             bounds: `bool`
-                Whether or not the data represent bounds.
+                Whether or not the data represent cell bounds. This is
+                used to inform the setting of chunksizes for the
+                bounds of 1-d coordinates.
 
                 .. versionadded:: (cfdm) NEXTVERSION
 
@@ -6541,7 +6543,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
             dataset_chunks = chunksizes
         elif chunksizes is not None:
             # Chunked as defined by the tuple of int given by 'data'
-            chunksizes = self._minimum_chunksizes(data, chunksizes, bounds)
+            chunksizes = self._one_d_chunks(data, chunksizes, bounds)
             return False, chunksizes, shards
 
         # Still here? Then work out the chunking strategy from the
@@ -6569,7 +6571,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
             # (250, 250, 4)). However, we only want one number per
             # dimension, so we choose the largest: [96, 250].
             chunksizes = [max(c) for c in chunksizes]
-            chunksizes = self._minimum_chunksizes(data, chunksizes, bounds)
+            chunksizes = self._one_d_chunks(data, chunksizes, bounds)
             return False, chunksizes, shards
         else:
             # The data is scalar, so 'chunksizes' is () => write the
@@ -7534,10 +7536,10 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
 
         return array
 
-    def _minimum_chunksizes(self, data, chunksizes, bounds=False):
-        """Set minimum chunksizes for particular forms of data.
+    def _one_d_chunks(self, data, chunksizes, bounds=False):
+        """Modify the chunksizes for 1-d data.
 
-        Return the chunksizes unchanged when
+        Return the input *chunksizes* unchanged when
 
         * The data is 0-d.
 
@@ -7545,14 +7547,14 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
 
         * The data is not 2-d when *bounds* is True.
 
-        * The chunksize is larger the the minimum 1-d chunksize.
+        * The input chunksize is larger the minimum 1-d chunksize.
 
-        For 1-d data (or 2-d data when *bounds* is True), when the
-        chunksize is less than "one_d_chunks":
+        For 1-d data (and 2-d data when *bounds* is True), when the input
+        chunk size is less than "one_d_chunks":
 
-        * If the total data size is less than the minimum 1-d
-          chunksize then set the chunksize so that there's a single
-          chunk.
+        * If the total data size is less than the minimum 1-d chunk
+          size (given by `write_vars['one_d_chunks']`) then set the
+          chunksize so that there is a single chunk.
 
         * If the total data size is greater than the minimum 1-d
           chunksize then set the chunksize to the minimum 1-d
@@ -7568,8 +7570,8 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
             chunksizes: `tuple`
                 The original chunksizes for the data
 
-            bounds: `bool`
-                Whether or not the data represent bounds.
+            bounds: `bool`, optional
+                Whether or not the data represent cell bounds.
 
         :Returns:
 
@@ -7587,7 +7589,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
             return chunksizes
 
         ndim = data.ndim
-        if (bounds and ndim != 2) or (not bounds and ndim != 1):
+        if (not bounds and ndim != 1) or (bounds and ndim != 2):
             # Do nothing if the data has the wrong shape
             return chunksizes
 
@@ -7595,7 +7597,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
         if prod(chunksizes) * itemsize <= min_size:
             shape = data.shape
             if bounds:
-                # Shape (N, M) bou
+                # Shape (N, M) bounds
                 chunksizes = (
                     min(shape[0], min_size // itemsize // shape[1]),
                     shape[1],

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -5385,7 +5385,8 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
         cfa="auto",
         reference_datetime=None,
         netcdf_backend=None,
-        h5py_options=None,ddd="4 MiB"
+        h5py_options=None,
+        one_d_chunks="4 MiB",
     ):
         """Write field and domain constructs to a dataset.
 
@@ -5632,6 +5633,12 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
 
                 .. versionadded:: (cfdm) 1.13.0.0
 
+            one_d_chunks: ``str`, `int`, `float`, or `None`, optional
+                Set the minimum chunksizes for 1-d data. See
+                `cfdm.write` for details.
+
+                .. versionadded:: (cfdm) NEXTVERSION
+
             cfa: `dict` or `None`, optional
                 Configure the creation of aggregation variables. See
                 `cfdm.write` for details.
@@ -5790,7 +5797,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
             # --------------------------------------------------------
             "dataset_chunks": dataset_chunks,
             "dataset_shards": dataset_shards,
-            "ddd": ddd,
+            "one_d_chunks": one_d_chunks,
             # --------------------------------------------------------
             # Quantization: Store unique Quantization objects, keyed
             #               by their output dataset variable names.
@@ -5843,18 +5850,18 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
                     f"{dataset_shards!r}."
                 )
 
-        # Parse the 'ddd' parameter
-        if ddd is not None and not isinstance(ddd, int):
+        # Parse the 'one_d_chunks' parameter
+        if one_d_chunks is not None and not isinstance(one_d_chunks, int):
             from dask.utils import parse_bytes
 
             try:
-                 self.write_vars["ddd"] = parse_bytes(ddd)
+                self.write_vars["one_d_chunks"] = parse_bytes(one_d_chunks)
             except (ValueError, AttributeError):
                 raise ValueError(
-                    "Invalid value for the 'ddd' keyword: "
-                    f"{ddd!r}."
+                    "Invalid value for the 'one_d_chunks' keyword: "
+                    f"{one_d_chunks!r}."
                 )
-        
+
         # Check fmt
         if fmt in NETCDF3_FMTS:
             if compress:
@@ -7541,7 +7548,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
         * The chunksize is larger the the minimum 1-d chunksize.
 
         For 1-d data (or 2-d data when *bounds* is True), when the
-        chunksize is less than "minimum_1d_chunks":
+        chunksize is less than "one_d_chunks":
 
         * If the total data size is less than the minimum 1-d
           chunksize then set the chunksize so that there's a single
@@ -7550,7 +7557,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
         * If the total data size is greater than the minimum 1-d
           chunksize then set the chunksize to the minimum 1-d
           chunksize.
-        
+
         .. versionadded:: (cfdm) NEXTVERSION
 
         :Parameters:
@@ -7570,11 +7577,11 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
                 The new chunksizes.
 
         """
-        four_MiB = self.write_vars['ddd']
-        if four_MiB is None:
-            # Do nothing if we've been asked not to
+        min_size = self.write_vars["one_d_chunks"]
+        if min_size is None:
+            # Do nothing if we've been asked to
             return chunksizes
-        
+
         if data is None or not chunksizes:
             # Do nothing if there's no data, or no initial chunksizes.
             return chunksizes
@@ -7584,19 +7591,17 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
             # Do nothing if the data has the wrong shape
             return chunksizes
 
-        four_MiB = self.write_vars['ddd']
-        print('ddd', four_MiB, chunksizes)
         itemsize = data.dtype.itemsize
-        if prod(chunksizes) * itemsize <= four_MiB:
+        if prod(chunksizes) * itemsize <= min_size:
             shape = data.shape
             if bounds:
-                # Shape (N, M) bounds
+                # Shape (N, M) bou
                 chunksizes = (
-                    min(shape[0], four_MiB // itemsize // shape[1]),
+                    min(shape[0], min_size // itemsize // shape[1]),
                     shape[1],
                 )
             else:
                 # Shape (N,)
-                chunksizes = (min(shape[0], four_MiB // itemsize),)
+                chunksizes = (min(shape[0], min_size // itemsize),)
 
         return chunksizes

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -7539,7 +7539,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
     def _one_d_chunks(self, data, chunksizes, bounds=False):
         """Modify the chunksizes for 1-d data.
 
-        Return the input *chunksizes* unchanged when
+        Return the input *chunksizes* unchanged when:
 
         * The data is 0-d.
 
@@ -7547,13 +7547,13 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
 
         * The data is not 2-d when *bounds* is True.
 
-        * The input chunksize is larger the minimum 1-d chunksize.
+        * The input chunksize is larger than the minimum 1-d chunksize.
 
         For 1-d data (and 2-d data when *bounds* is True), when the input
-        chunk size is less than "one_d_chunks":
+        chunksize is less than "one_d_chunks":
 
-        * If the total data size is less than the minimum 1-d chunk
-          size (given by `write_vars['one_d_chunks']`) then set the
+        * If the total data size is less than the minimum 1-d chunksize
+          (given by `write_vars['one_d_chunks']`) then set the
           chunksize so that there is a single chunk.
 
         * If the total data size is greater than the minimum 1-d
@@ -7568,7 +7568,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
                 The data to be chunked.
 
             chunksizes: `tuple`
-                The original chunksizes for the data
+                The original chunksizes for the data.
 
             bounds: `bool`, optional
                 Whether or not the data represent cell bounds.

--- a/cfdm/read_write/netcdf/netcdfwrite.py
+++ b/cfdm/read_write/netcdf/netcdfwrite.py
@@ -1538,6 +1538,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
                 self.implementation.get_data_axes(f, coord_key),
                 omit=omit,
                 construct_type=self.implementation.get_construct_type(coord),
+                bounds=True,
             )
 
         extra["bounds"] = ncvar
@@ -2991,6 +2992,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
         domain_variable=False,
         construct_type=None,
         chunking=None,
+        bounds=False,
     ):
         """Creates a new netCDF variable for a construct.
 
@@ -3041,6 +3043,11 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
                 data.
 
                 .. versionadded:: (cfdm) 1.12.0.0
+
+            bounds: `bool`
+                Whether or not the data represent bounds.
+
+                .. versionadded:: (cfdm) NEXTVERSION
 
         :Returns:
 
@@ -3138,7 +3145,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
             contiguous, chunksizes, shards = chunking
         else:
             contiguous, chunksizes, shards = self._chunking_parameters(
-                data, ncdimensions
+                data, ncdimensions, bounds
             )
 
         logger.debug(
@@ -5373,12 +5380,12 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
         group=True,
         coordinates=False,
         omit_data=None,
-        dataset_chunks="4MiB",
+        dataset_chunks="4 MiB",
         dataset_shards=None,
         cfa="auto",
         reference_datetime=None,
         netcdf_backend=None,
-        h5py_options=None,
+        h5py_options=None,ddd="4 MiB"
     ):
         """Write field and domain constructs to a dataset.
 
@@ -5617,7 +5624,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
 
             dataset_chunks: `str`, `int`, or `float`, optional
                 The dataset chunking strategy. The default value is
-                "4MiB". See `cfdm.write` for details.
+                "4 MiB". See `cfdm.write` for details.
 
             dataset_shards: `int` or `None`, optional
                 The Zarr dataset sharding strategy. The default value
@@ -5783,6 +5790,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
             # --------------------------------------------------------
             "dataset_chunks": dataset_chunks,
             "dataset_shards": dataset_shards,
+            "ddd": ddd,
             # --------------------------------------------------------
             # Quantization: Store unique Quantization objects, keyed
             #               by their output dataset variable names.
@@ -5835,6 +5843,18 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
                     f"{dataset_shards!r}."
                 )
 
+        # Parse the 'ddd' parameter
+        if ddd is not None and not isinstance(ddd, int):
+            from dask.utils import parse_bytes
+
+            try:
+                 self.write_vars["ddd"] = parse_bytes(ddd)
+            except (ValueError, AttributeError):
+                raise ValueError(
+                    "Invalid value for the 'ddd' keyword: "
+                    f"{ddd!r}."
+                )
+        
         # Check fmt
         if fmt in NETCDF3_FMTS:
             if compress:
@@ -6457,7 +6477,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
         """
         pass
 
-    def _chunking_parameters(self, data, ncdimensions):
+    def _chunking_parameters(self, data, ncdimensions, bounds):
         """Set chunking parameters for a dataset variable.
 
         .. versionadded:: (cfdm) 1.11.2.0
@@ -6469,6 +6489,11 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
 
             ncdimensions: `tuple`
                 The dataset dimensions of the data.
+
+            bounds: `bool`
+                Whether or not the data represent bounds.
+
+                .. versionadded:: (cfdm) NEXTVERSION
 
         :Returns:
 
@@ -6486,6 +6511,11 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
         # Dataset chunk strategy: Either use that provided on the
         # data, or else work it out.
         # ------------------------------------------------------------
+        if ncdimensions is not None and self._compressed_data(ncdimensions):
+            # Base the dataset chunks on the compressed data that is
+            # going into the dataset
+            data = data.source().source()
+
         # Get the chunking strategy defined by the data itself
         chunksizes = self.implementation.nc_get_dataset_chunksizes(data)
         shards = self.implementation.nc_get_dataset_shards(data)
@@ -6504,6 +6534,7 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
             dataset_chunks = chunksizes
         elif chunksizes is not None:
             # Chunked as defined by the tuple of int given by 'data'
+            chunksizes = self._minimum_chunksizes(data, chunksizes, bounds)
             return False, chunksizes, shards
 
         # Still here? Then work out the chunking strategy from the
@@ -6515,27 +6546,23 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
         # Still here? Then work out the chunks from both the
         # size-in-bytes given by dataset_chunks (e.g. 1024, or '1
         # KiB'), and the data shape (e.g. (12, 73, 96)).
-        if self._compressed_data(ncdimensions):
-            # Base the dataset chunks on the compressed data that is
-            # going into the dataset
-            d = self.implementation.get_compressed_array(data)
-        else:
-            d = data
-
-        d_dtype = d.dtype
+        d_dtype = data.dtype
         dtype = g["datatype"].get(d_dtype, d_dtype)
 
         from dask import config as dask_config
         from dask.array.core import normalize_chunks
 
         with dask_config.set({"array.chunk-size": dataset_chunks}):
-            chunksizes = normalize_chunks("auto", shape=d.shape, dtype=dtype)
+            chunksizes = normalize_chunks(
+                "auto", shape=data.shape, dtype=dtype
+            )
 
         if chunksizes:
             # 'chunksizes' looks something like ((96, 96, 96, 50),
             # (250, 250, 4)). However, we only want one number per
             # dimension, so we choose the largest: [96, 250].
             chunksizes = [max(c) for c in chunksizes]
+            chunksizes = self._minimum_chunksizes(data, chunksizes, bounds)
             return False, chunksizes, shards
         else:
             # The data is scalar, so 'chunksizes' is () => write the
@@ -7499,3 +7526,77 @@ class NetCDFWrite(NetCDFWriteUgrid, IOWrite):
             array = array.astype(dtype)
 
         return array
+
+    def _minimum_chunksizes(self, data, chunksizes, bounds=False):
+        """Set minimum chunksizes for particular forms of data.
+
+        Return the chunksizes unchanged when
+
+        * The data is 0-d.
+
+        * The data is not 1-d when *bounds* is False.
+
+        * The data is not 2-d when *bounds* is True.
+
+        * The chunksize is larger the the minimum 1-d chunksize.
+
+        For 1-d data (or 2-d data when *bounds* is True), when the
+        chunksize is less than "minimum_1d_chunks":
+
+        * If the total data size is less than the minimum 1-d
+          chunksize then set the chunksize so that there's a single
+          chunk.
+
+        * If the total data size is greater than the minimum 1-d
+          chunksize then set the chunksize to the minimum 1-d
+          chunksize.
+        
+        .. versionadded:: (cfdm) NEXTVERSION
+
+        :Parameters:
+
+            data: `Data`
+                The data to be chunked.
+
+            chunksizes: `tuple`
+                The original chunksizes for the data
+
+            bounds: `bool`
+                Whether or not the data represent bounds.
+
+        :Returns:
+
+            `tuple`
+                The new chunksizes.
+
+        """
+        four_MiB = self.write_vars['ddd']
+        if four_MiB is None:
+            # Do nothing if we've been asked not to
+            return chunksizes
+        
+        if data is None or not chunksizes:
+            # Do nothing if there's no data, or no initial chunksizes.
+            return chunksizes
+
+        ndim = data.ndim
+        if (bounds and ndim != 2) or (not bounds and ndim != 1):
+            # Do nothing if the data has the wrong shape
+            return chunksizes
+
+        four_MiB = self.write_vars['ddd']
+        print('ddd', four_MiB, chunksizes)
+        itemsize = data.dtype.itemsize
+        if prod(chunksizes) * itemsize <= four_MiB:
+            shape = data.shape
+            if bounds:
+                # Shape (N, M) bounds
+                chunksizes = (
+                    min(shape[0], four_MiB // itemsize // shape[1]),
+                    shape[1],
+                )
+            else:
+                # Shape (N,)
+                chunksizes = (min(shape[0], four_MiB // itemsize),)
+
+        return chunksizes

--- a/cfdm/read_write/write.py
+++ b/cfdm/read_write/write.py
@@ -601,18 +601,22 @@ class write(ReadWrite):
 
             * `int` or `float` or `str`
 
-              The size in bytes of the dataset chunks. A floating
-              point value is rounded down to the nearest integer, and
-              a string represents a quantity of byte
-              units. "Square-like" chunk shapes are preferred,
-              maximising the amount of chunks that are completely
-              filled with data values. For instance a chunksize of
-              1024 bytes may be specified with any of ``1024``,
-              ``1024.9``, ``'1024'``, ``'1024.9'``, ``'1024 B'``, ``'1
-              KiB'``, ``'0.001024 MB'``, etc. Recognised byte units
-              are (case insensitive): ``B``, ``KiB``, ``MiB``,
-              ``GiB``, ``TiB``, ``PiB``, ``KB``, ``MB``, ``GB``,
-              ``TB``, and ``PB``. Spaces in strings are optional.
+              The size in bytes of the dataset chunks. "Square-like"
+              chunk shapes are preferred, maximising the amount of
+              chunks that are completely filled with data values.
+
+              Values are parsed as bytes with optional units as
+              accepted by `dask.utils.parse_bytes`, where a string
+              represents a quantity of byte units and a floating point
+              value is rounded down to the nearest integer.
+              
+              For instance a chunksize of 1024 bytes may be specified
+              with any of ``1024``, ``1024.9``, ``'1024'``,
+              ``'1024.9'``, ``'1024 B'``, ``'1 KiB'``, ``'0.001024
+              MB'``, etc. Recognised byte units are (case
+              insensitive): ``B``, ``KiB``, ``MiB``, ``GiB``, ``TiB``,
+              ``PiB``, ``KB``, ``MB``, ``GB``, ``TB``, and
+              ``PB``. Spaces in strings are optional.
 
             .. note:: When the dataset chunk size is defined by a
                       number of bytes (taken either from the
@@ -703,13 +707,12 @@ class write(ReadWrite):
               minimum size, then these larger chunks will be used.
 
               Values are parsed as bytes with optional units as
-              accepted by `dask.utils.parse_bytes`, where
-              a string represents a quantity of byte
-              units and a floating point value is rounded down
-              to the nearest integer.
+              accepted by `dask.utils.parse_bytes`, where a string
+              represents a quantity of byte units and a floating point
+              value is rounded down to the nearest integer.
               
-              For instance a chunksize of 1024 bytes may be
-              specified with any of ``1024``, ``1024.9``, ``'1024'``,
+              For instance a chunksize of 1024 bytes may be specified
+              with any of ``1024``, ``1024.9``, ``'1024'``,
               ``'1024.9'``, ``'1024 B'``, ``'1 KiB'``, ``'0.001024
               MB'``, etc. Recognised byte units are (case
               insensitive): ``B``, ``KiB``, ``MiB``, ``GiB``, ``TiB``,

--- a/cfdm/read_write/write.py
+++ b/cfdm/read_write/write.py
@@ -575,6 +575,9 @@ class write(ReadWrite):
             Ignored for netCDF3 output formats, for which all data is
             always written out contiguously.
 
+            See the *one_d_chunks* parameter for how 1-d arrays may be
+            given special treatment.
+
             .. note:: By default, a data array returned by
                       `{{package}}.read` stores its dataset chunking
                       strategy from the dataset being read. When this
@@ -678,10 +681,8 @@ class write(ReadWrite):
               dimension.
 
         one_d_chunks: `str`, `int`, `float`, or `None`, optional
-            Set the minimum chunksizes for 1-d data.
-
-            Also set the minimum chunksizes for the bounds of 1-d
-            coordinates.
+            Set the chunking strategy for 1-d data arrays, and the
+            bounds arrays of 1-d coordinates.
 
             By default, *one_d_chunks* is ``'4 MiB'``, i.e. 4194304
             bytes.
@@ -693,13 +694,13 @@ class write(ReadWrite):
               The minimum size in bytes of the dataset chunks for a
               1-d array and the bounds array of 1-d coordinates.
 
-              If a 1-d array, or the bounds array of 1-d coordinates,
-              is smaller than the minimum size then a single dataset
-              chunk of the array size will be created.
+              If a 1-d data array, or the bounds array of 1-d
+              coordinates, is smaller than the minimum size then a
+              single dataset chunk of that array size will be created.
 
-              If chunking behaviour as described by *dataset_chunks*
-              implies chunks that are larger than the minimum size,
-              then these larger chunks will be used.
+              If the chunking behaviour as described by
+              *dataset_chunks* implies chunks that are larger than the
+              minimum size, then these larger chunks will be used.
 
               A floating point value is rounded down to the nearest
               integer, and a string represents a quantity of byte
@@ -714,8 +715,8 @@ class write(ReadWrite):
             * `None`
 
               No special treatment. The dataset chunking behaviour for
-              a 1-d array, and the bounds array of 1-d coordinates, is
-              as described by *dataset_chunks*.
+              a 1-d data array, and the bounds array of 1-d
+              coordinates, is as described by *dataset_chunks*.
 
             .. versionadded:: (cfdm) NEXTVERSION
 

--- a/cfdm/read_write/write.py
+++ b/cfdm/read_write/write.py
@@ -677,6 +677,48 @@ class write(ReadWrite):
               result in shards that span 3 chunks along each
               dimension.
 
+        one_d_chunks: `str`, `int`, `float`, or `None`, optional
+            Set the minimum chunksizes for 1-d data.
+
+            Also set the minimum chunksizes for the bounds of 1-d
+            coordinates.
+
+            By default, *one_d_chunks* is ``'4 MiB'``, i.e. 4194304
+            bytes.
+
+            The *one_d_chunks* parameter may be one of:
+
+            * `int` or `float` or `str`
+
+              The minimum size in bytes of the dataset chunks for a
+              1-d array and the bounds array of 1-d coordinates.
+
+              If a 1-d array, or the bounds array of 1-d coordinates,
+              is smaller than the minimum size then a single dataset
+              chunk of the array size will be created.
+
+              If chunking behaviour as described by *dataset_chunks*
+              implies chunks that are larger than the minimum size,
+              then these larger chunks will be used.
+
+              A floating point value is rounded down to the nearest
+              integer, and a string represents a quantity of byte
+              units. For instance a chunksize of 1024 bytes may be
+              specified with any of ``1024``, ``1024.9``, ``'1024'``,
+              ``'1024.9'``, ``'1024 B'``, ``'1 KiB'``, ``'0.001024
+              MB'``, etc. Recognised byte units are (case
+              insensitive): ``B``, ``KiB``, ``MiB``, ``GiB``, ``TiB``,
+              ``PiB``, ``KB``, ``MB``, ``GB``, ``TB``, and
+              ``PB``. Spaces in strings are optional.
+
+            * `None`
+
+              No special treatment. The dataset chunking behaviour for
+              a 1-d array, and the bounds array of 1-d coordinates, is
+              as described by *dataset_chunks*.
+
+            .. versionadded:: (cfdm) NEXTVERSION
+
         cfa: `str` or `dict` or `None`, optional
             Specify which netCDF variables, if any, should be written
             as CF-netCDF aggregation variables.
@@ -929,7 +971,8 @@ class write(ReadWrite):
         cfa="auto",
         extra_write_vars=None,
         netcdf_backend=None,
-        h5py_options=None,ddd="4 MiB",
+        h5py_options=None,
+        one_d_chunks="4 MiB",
     ):
         """Write field and domain constructs to a dataset."""
         # Flatten the sequence of intput fields
@@ -992,8 +1035,8 @@ class write(ReadWrite):
             omit_data=omit_data,
             dataset_chunks=dataset_chunks,
             dataset_shards=dataset_shards,
+            one_d_chunks=one_d_chunks,
             cfa=cfa,
             netcdf_backend=netcdf_backend,
             h5py_options=h5py_options,
-            ddd=ddd,
         )

--- a/cfdm/read_write/write.py
+++ b/cfdm/read_write/write.py
@@ -702,9 +702,13 @@ class write(ReadWrite):
               *dataset_chunks* implies chunks that are larger than the
               minimum size, then these larger chunks will be used.
 
-              A floating point value is rounded down to the nearest
-              integer, and a string represents a quantity of byte
-              units. For instance a chunksize of 1024 bytes may be
+              Values are parsed as bytes with optional units as
+              accepted by `dask.utils.parse_bytes`, where
+              a string represents a quantity of byte
+              units and a floating point value is rounded down
+              to the nearest integer.
+              
+              For instance a chunksize of 1024 bytes may be
               specified with any of ``1024``, ``1024.9``, ``'1024'``,
               ``'1024.9'``, ``'1024 B'``, ``'1 KiB'``, ``'0.001024
               MB'``, etc. Recognised byte units are (case

--- a/cfdm/read_write/write.py
+++ b/cfdm/read_write/write.py
@@ -929,7 +929,7 @@ class write(ReadWrite):
         cfa="auto",
         extra_write_vars=None,
         netcdf_backend=None,
-        h5py_options=None,
+        h5py_options=None,ddd="4 MiB",
     ):
         """Write field and domain constructs to a dataset."""
         # Flatten the sequence of intput fields
@@ -995,4 +995,5 @@ class write(ReadWrite):
             cfa=cfa,
             netcdf_backend=netcdf_backend,
             h5py_options=h5py_options,
+            ddd=ddd,
         )

--- a/cfdm/test/test_dsg.py
+++ b/cfdm/test/test_dsg.py
@@ -186,6 +186,7 @@ class DSGTest(unittest.TestCase):
         self.assertTrue(q._equals(self.a, q.data.array))
 
         cfdm.write(f, tempfile)
+
         g = cfdm.read(tempfile)
 
         self.assertEqual(len(g), len(f))
@@ -197,8 +198,8 @@ class DSGTest(unittest.TestCase):
         # Test creation
         # ------------------------------------------------------------
         # Define the ragged array values
-        ragged_array = np.array(
-            [280, 282.5, 281, 279, 278, 279.5], dtype="float32"
+        ragged_array = cfdm.Data(
+            np.array([280, 282.5, 281, 279, 278, 279.5], dtype="float32")
         )
 
         # Define the count array values

--- a/cfdm/test/test_read_write.py
+++ b/cfdm/test/test_read_write.py
@@ -1631,6 +1631,32 @@ class read_writeTest(unittest.TestCase):
         # Check that we can read data after the initial scan
         self.assertEqual(f[0].coordinate("axis=T")[2].array, 2.2117104e09)
 
+    def test_write_one_d_chunks(self):
+        """Test cfdm.write with the one_d_chunks keyword."""
+        f = self.f0.copy()
+
+        x = f.dimension_coordinate("longitude")
+        x.data.nc_set_dataset_chunksizes((1,))
+        x.bounds.data.nc_set_dataset_chunksizes((1, 2))
+        cfdm.write(f, tmpfile, one_d_chunks=None)
+
+        g = cfdm.read(tmpfile, one_d_chunks=None)[0]
+        x = g.dimension_coordinate("longitude")
+        self.assertEqual(x.data.nc_dataset_chunksizes(), (1,))
+        self.assertEqual(x.bounds.data.nc_dataset_chunksizes(), (1, 2))
+
+        cfdm.write(f, tmpfile, one_d_chunks="4 MiB")
+        g = cfdm.read(tmpfile)[0]
+        x = g.dimension_coordinate("longitude")
+        self.assertEqual(x.data.nc_dataset_chunksizes(), (8,))
+        self.assertEqual(x.bounds.data.nc_dataset_chunksizes(), (8, 2))
+
+        cfdm.write(f, tmpfile, one_d_chunks="32 B")
+        g = cfdm.read(tmpfile)[0]
+        x = g.dimension_coordinate("longitude")
+        self.assertEqual(x.data.nc_dataset_chunksizes(), (4,))
+        self.assertEqual(x.bounds.data.nc_dataset_chunksizes(), (2, 2))
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())


### PR DESCRIPTION
Fixes #414

The idea is to add a bit of functionality to `NetCDFWrite._chunking_parameters` to modify the chunks it returns for 1-d arrays, and the bounds arrays of 1-d coordinates. There's also a new `cfdm.write` keyword `one_d_chunks` to control the behaviour.