### PR TITLE
Improve `cfdm.environment` (sort, better test) & update docs

### DIFF
--- a/cfdm/abstract/implementation.py
+++ b/cfdm/abstract/implementation.py
@@ -35,8 +35,12 @@ class Implementation(metaclass=abc.ABCMeta):
 
         >>> i = cfdm.implementation()  # child CF data model implementation
         >>> sorted(i.classes())
-        ['AuxiliaryCoordinate',
+        ['AggregatedArray',
+         'AuxiliaryCoordinate',
          'Bounds',
+         'BoundsFromNodesArray',
+         'CellConnectivity',
+         'CellConnectivityArray',
          'CellMeasure',
          'CellMethod',
          'CoordinateConversion',
@@ -48,18 +52,24 @@ class Implementation(metaclass=abc.ABCMeta):
          'Domain',
          'DomainAncillary',
          'DomainAxis',
+         'DomainTopology',
          'Field',
          'FieldAncillary',
          'GatheredArray',
          'Index',
          'InteriorRing',
+         'InterpolationParameter',
          'List',
-         'NetCDF4Array',
          'NodeCountProperties',
          'PartNodeCountProperties',
+         'PointTopologyArray',
+         'Quantization',
          'RaggedContiguousArray',
          'RaggedIndexedArray',
-         'RaggedIndexedContiguousArray']
+         'RaggedIndexedContiguousArray',
+         'SubsampledArray',
+         'TiePointIndex',
+         'XnetcdfArray']
 
         """
         return self._class.copy()

--- a/cfdm/data/abstract/filearray.py
+++ b/cfdm/data/abstract/filearray.py
@@ -416,7 +416,7 @@ class FileArray(Array):
                 if isinstance(protocol, tuple):
                     protocol = protocol[0]
 
-            # Only a normalise local name
+            # Only normalise a local name
             if protocol in (None, "file", "local"):
                 filename = abspath(filename)
 

--- a/cfdm/data/netcdfarray.py
+++ b/cfdm/data/netcdfarray.py
@@ -8,7 +8,7 @@ class NetCDFArray:
     """A netCDF array accessed with `netCDF4`.
 
     Deprecated at version 1.11.2.0 and is no longer available. Use
-    `cfdm.NetCDF4Array` instead.
+    `cfdm.XnetcdfArray` instead.
 
     .. versionadded:: (cfdm) 1.7.0
 
@@ -101,5 +101,5 @@ class NetCDFArray:
         """
         raise DeprecationError(
             f"{self.__class__.__name__} was deprecated at version 1.11.2.0 "
-            "and is no longer available. Use cfdm.NetCDF4Array instead."
+            "and is no longer available. Use cfdm.XnetcdfArray instead."
         )

--- a/cfdm/functions.py
+++ b/cfdm/functions.py
@@ -458,6 +458,7 @@ def environment(display=True, paths=True):
         "cftime": _get_module_info("cftime"),
         "cfunits": _get_module_info("cfunits"),
         "cfdm": (__version__, os.path.abspath(__file__)),
+        "uritools": _get_module_info("uritools", try_except=True),
     }
     string = "{0}: {1!s}"
     if paths:
@@ -470,6 +471,12 @@ def environment(display=True, paths=True):
             for dep, info in dependency_version_paths_mapping.items()
         ]
     )
+
+    # There are a lot of dependencies (compulsory + optional) to print so
+    # show them in asciibetical order, with the happy coincidence that the
+    # 'cf*' libraries, 'Platform' and 'Python' still come near the top (the
+    # (latter because of the capitalisation) so are easy to pick out.
+    out.sort()
 
     if display:
         print("\n".join(out))  # pragma: no cover

--- a/cfdm/read_write/netcdf/netcdfread.py
+++ b/cfdm/read_write/netcdf/netcdfread.py
@@ -5829,14 +5829,14 @@ class NetCDFRead(IORead, FieldChecker, NetCDFCheckerMixin):
 
             return_kwargs_only: `bool`, optional
                 Only return the kwargs dictionary, without
-                instantiating a new `NetCDF4Array` or `H5netcdfArray`.
+                instantiating a new `XnetcdfArray`.
 
                 .. versionadded:: (cfdm) 1.10.0.1
 
         :Returns:
 
             (array, `dict`) or (`None`, `dict`) or `dict`
-                The new `NetCDF4Array` or `H5netcdfArray` instance and
+                The new `XnetcdfArray` instance and
                 a dictionary of the kwargs used to create it. If the
                 array could not be created then `None` is returned in
                 its place. If *return_kwargs_only* then only the
@@ -5909,7 +5909,7 @@ class NetCDFRead(IORead, FieldChecker, NetCDFCheckerMixin):
 
             if backend == "xarray":
                 # For xarray, we don't want to create an `XnetcdfArray`
-                # instance, because 'variable' will wither contain its
+                # instance, because 'variable' will either contain its
                 # own Dask array (if the xarray 'chunks' argument was
                 # not `None`), or a `numpy` array (or similar).
                 array = variable.backend_accessor.data

--- a/cfdm/test/test_functions.py
+++ b/cfdm/test/test_functions.py
@@ -8,8 +8,10 @@ import platform
 import sys
 import tempfile
 import unittest
+from importlib.metadata import requires
 
 import numpy as np
+from packaging.requirements import Requirement
 
 faulthandler.enable()  # to debug seg faults and timeouts
 
@@ -205,6 +207,7 @@ class FunctionsTest(unittest.TestCase):
         self.assertIsInstance(e, list)
         self.assertIsInstance(ep, list)
 
+        # Test some specific components including their paths
         components = ["Platform: ", "netCDF4: ", "numpy: ", "cftime: "]
         for component in components:
             self.assertTrue(any(s.startswith(component) for s in e))
@@ -220,6 +223,22 @@ class FunctionsTest(unittest.TestCase):
             f"Python: {platform.python_version()}",
         ]:
             self.assertIn(component, ep)
+
+        # Ensure all hard dependencies are reported on, to help keep
+        # the environment function output up to date
+        cfdm_hard_dependencies = {
+            req.name
+            for req in map(Requirement, requires("cfdm") or [])
+            if not req.marker or "extra" not in str(req.marker)
+        }  # get as a set for subset comparison later
+        for output in (e, ep):
+            dep_names = set()
+            for entry in output:
+                dep_names.add(entry.split(":")[0])
+            self.assertTrue(
+                cfdm_hard_dependencies.issubset(dep_names),
+                f"Missing dependencies: {cfdm_hard_dependencies - dep_names}",
+            )
 
     def test_example_field(self):
         """Test the `example_field` function."""


### PR DESCRIPTION
Went in to do some minor cfdm docs updates, but ended up bundling in a bit more. Overall:

* remove reference to the deprecated `NetCDF4Array` being the up-to-date API usage and update some other docstrings;
* add a missing dependency to the `environment()` function (`uritools`);
* whilst I was updating `environment()` thought it would be useful to sort it asciibetically so it is easier to find a given library amongst the output, now we have so many dependencies to report on (will do the same for cf-python's equivalent unless there's any objection)...
* ...and update the testing to ensure we don't forget to add any dependencies as they are added.
